### PR TITLE
Booking availability patch subevents

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -10,8 +10,8 @@ This page contains an overview of all possible error types inside the `https://a
 *   **Title**: `Calendar type not supported`
 *   **Status**: `400`
 
-The request you are trying to perform is not supported on the calendar type of the given [event](/models/event-calendarType.json) or [place](/models/place-calendarType.json). For example, you cannot update the bookingAvailability of events or places with calendar types `periodic` and `permanent`.
+The request you are trying to perform is not supported on the calendar type of the given [event](/models/event-calendarType.json) or [place](/models/place-calendarType.json). For example, you cannot add or update subEvents to offers that use calendar type `periodic` or `permanent`.
 
-Usually the `detail` of the error will contain more information.
+Usually the `detail` of the error will contain more information about the specific operation that is not supported and on which calendar types.
 
 Try using an event or place id with a calendar type that is supported by the operation that you are trying to perform.

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -157,7 +157,7 @@
       ],
       "patch": {
         "operationId": "patch-subEvents",
-        "description": "Updates the given subEvents on the event with the given `eventId`.\n\nAllows partial updates, omitted properties will be ignored and remain unchanged. Omitted subEvents will also remain unchanged.\n\nOnly events with calendar type `single` and `multiple` have subEvents, so only events with those calendar types support this endpoint.",
+        "description": "Updates the given subEvents on the event with the given `eventId`.\n\nAllows partial updates, omitted properties will be ignored and remain unchanged. Omitted subEvents will also remain unchanged.\n\nEvery subEvent to update requires an `id` property that is an integer that corresponds to their index in the list of subEvents on the parent event. For example `0` for the first subEvent, `1` for the second subEvent, and so on.\n\n<!-- theme: warning -->\n\n> Note! If you change the `startDate` of a subEvent, the subEvents will be re-ordered on the parent event afterwards because subEvents are always sorted chronologically.\n\nOnly events with calendar type `single` and `multiple` have subEvents, so only events with those calendar types support this endpoint.",
         "tags": [
           "Events"
         ],

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -148,6 +148,246 @@
           }
         ]
       }
+    },
+    "/events/{eventId}/subEvents": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/eventId"
+        }
+      ],
+      "patch": {
+        "operationId": "patch-subEvents",
+        "description": "Updates the given subEvents on the event with the given `eventId`.\n\nAllows partial updates, omitted properties will be ignored and remain unchanged. Omitted subEvents will also remain unchanged.\n\nOnly events with calendar type `single` and `multiple` have subEvents, so only events with those calendar types support this endpoint.",
+        "tags": [
+          "Events"
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content. The subEvents have been successfully updated."
+          },
+          "400": {
+            "description": "Bad Request. Possbile error types:\n\n* https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "type": "https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
+                      "title": "Calendar type not supported",
+                      "status": 400,
+                      "detail": "Not allowed to update subEvents on calendar type: \"permanent\". Only subEvents on single and multiple calendar types can be updated."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/EventNotFound"
+          }
+        },
+        "summary": "Partially update subEvents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "description": "",
+                "minItems": 1,
+                "uniqueItems": true,
+                "x-examples": {
+                  "example-1": [
+                    {
+                      "id": 0,
+                      "startDate": "2021-01-18T19:35:58+01:00",
+                      "endDate": "2021-02-05T20:30:00+00:00",
+                      "status": {
+                        "type": "Unavailable",
+                        "reason": {
+                          "nl": "Omwille van preventieve coronamaatregelen is het concert geannuleerd",
+                          "en": "The concert has been canceled due to preventive corona measures"
+                        }
+                      },
+                      "bookingAvailability": {
+                        "type": "Unavailable"
+                      }
+                    }
+                  ]
+                },
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "Index of the subEvent to update on the parent event. `0` for the first subEvent, `1` for the second event, and so on.",
+                      "example": 0
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2021-05-17T22:00:00+00:00",
+                      "minLength": 1,
+                      "description": "The date & time that the subEvent starts."
+                    },
+                    "endDate": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2021-05-17T22:00:00+00:00",
+                      "minLength": 1,
+                      "description": "The date & time that the subEvent ends."
+                    },
+                    "status": {
+                      "type": "object",
+                      "description": "Indicates if the subEvent is still happening as scheduled or not.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "minLength": 1,
+                          "example": "Available",
+                          "description": "Required if `status` is included.\nOne of three possible status types.\n\n- `Available`: The subEvent is happening as scheduled\n- `TemporarilyUnavailable`: The subEvent will be postponed\n- `Unavailable`: The subEvent is permanently cancelled",
+                          "enum": [
+                            "Available",
+                            "TemporarilyUnavailable",
+                            "Unavailable"
+                          ]
+                        },
+                        "reason": {
+                          "description": "The reason of the status on the event, as a localized human-readable text.",
+                          "type": "object",
+                          "minProperties": 1,
+                          "properties": {
+                            "nl": {
+                              "type": "string",
+                              "description": "Dutch reason",
+                              "example": "Nederlandse reden"
+                            },
+                            "fr": {
+                              "type": "string",
+                              "description": "French reason",
+                              "example": "Raison français"
+                            },
+                            "de": {
+                              "type": "string",
+                              "description": "German reason",
+                              "example": "Deutscher Grund"
+                            },
+                            "en": {
+                              "type": "string",
+                              "description": "English reason",
+                              "example": "English reason"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "bookingAvailability": {
+                      "type": "object",
+                      "description": "Indicates if the subEvent still has tickets or places available for booking.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Required if `bookingAvailability` is included.\nOne of two possible status types.\n\n- `Available`: The subEvent still has tickets or places available.\n- `Unavailable`: The subEvent has no more tickets or places available.",
+                          "example": "Available",
+                          "enum": [
+                            "Available",
+                            "Unavailable"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              },
+              "examples": {
+                "Updating the dates of the first subEvent": {
+                  "value": [
+                    {
+                      "id": 0,
+                      "startDate": "2021-05-17T22:00:00+00:00",
+                      "endDate": "2021-05-17T22:00:00+00:00"
+                    }
+                  ]
+                },
+                "Updating the status of the second subEvent": {
+                  "value": [
+                    {
+                      "id": 1,
+                      "status": {
+                        "type": "Unavailable",
+                        "reason": {
+                          "nl": "Afgelast wegens corona"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "Updating the booking availability of the third subEvent": {
+                  "value": [
+                    {
+                      "id": 2,
+                      "bookingAvailability": {
+                        "type": "Unavailable"
+                      }
+                    }
+                  ]
+                },
+                "Updating multiple": {
+                  "value": [
+                    {
+                      "id": 0,
+                      "startDate": "2021-05-17T22:00:00+00:00",
+                      "endDate": "2021-05-17T22:00:00+00:00"
+                    },
+                    {
+                      "id": 1,
+                      "status": {
+                        "type": "Unavailable",
+                        "reason": {
+                          "nl": "Afgelast wegens corona"
+                        }
+                      }
+                    },
+                    {
+                      "id": 2,
+                      "bookingAvailability": {
+                        "type": "Unavailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "description": "The subEvents to update, with the properties to update. \n\nEach subEvent must have an `id` property to indicate which subEvent should be updated. This `id` is the position of the subEvent in the list of subEvents on the parent event. For example `0` for the first subEvent, `1` for the second subEvent, and so on.\n\nAll other properties are optional, and only properties that are included will be updated. No subEvents or properties will be removed."
+        },
+        "security": [
+          {
+            "USER_ACCESS_TOKEN": []
+          },
+          {
+            "CLIENT_ACCESS_TOKEN": []
+          }
+        ]
+      }
     }
   },
   "components": {


### PR DESCRIPTION
### Added

- Added documentation for `PATCH /events/{eventId}/subEvents` endpoint

### Changed

- Slightly changed the documentation of the `calendar-type-not-supported` endpoint to use a simpler example than `bookingAvailability` which is very specific

---

To preview, select the `booking-availability-patch-subevents` branch in Stoplight

