### PR TITLE
III-4153 Add extra booking availability errors

### DIFF
--- a/reference/entry.json
+++ b/reference/entry.json
@@ -64,7 +64,7 @@
             "description": "No Content"
           },
           "400": {
-            "description": "Bad Request. Possbile error types:\n\n* https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
+            "description": "Bad Request. Possbile error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data\n* https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -166,7 +166,7 @@
             "description": "No Content. The subEvents have been successfully updated."
           },
           "400": {
-            "description": "Bad Request. Possbile error types:\n\n* https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
+            "description": "Bad Request. Possbile error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data\n* https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
             "content": {
               "application/problem+json": {
                 "schema": {


### PR DESCRIPTION
### Added

- Added `body` errors for `PUT /events/{eventId}/bookingAvailability`
- Added `body` errors for `PATCH /events/{eventId}/subEvents`

---

Ticket: https://jira.uitdatabank.be/browse/III-4153

