### PR TITLE
Update entry api to openapi 3.1.0

### DIFF
--- a/reference/entry.json
+++ b/reference/entry.json
@@ -439,7 +439,8 @@
             "refreshUrl": "",
             "scopes": {}
           }
-        }
+        },
+        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md)"
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
@@ -449,7 +450,8 @@
             "refreshUrl": "",
             "scopes": {}
           }
-        }
+        },
+        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md)"
       }
     },
     "parameters": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
     "title": "Entry API",
     "version": "3.0",

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -195,7 +195,7 @@
             "$ref": "#/components/responses/EventNotFound"
           }
         },
-        "summary": "Partially update subEvents",
+        "summary": "Update subEvents",
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
### Added

- Added descriptions to entry api security schemes

### Changed

- Changed entry api openapi version to 3.1.0
- Shortened operation name

