### PR TITLE
Fix shared event/place models for new Stoplight Studio version

### DIFF
--- a/models/event-@id.json
+++ b/models/event-@id.json
@@ -6,7 +6,7 @@
   "example": "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3",
   "description": "A unique URI that acts as globally unique ID for the [event](./event.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",
   "readOnly": true,
-  "x-examples": {
-    "Example": "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3"
-  }
+  "examples": [
+    "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3"
+  ]
 }

--- a/models/event-audience.json
+++ b/models/event-audience.json
@@ -16,15 +16,15 @@
   "required": [
     "audienceType"
   ],
-  "x-examples": {
-    "Everyone": {
+  "examples": [
+    {
       "audienceType": "everyone"
     },
-    "Members": {
+    {
       "audienceType": "members"
     },
-    "Education": {
+    {
       "audienceType": "education"
     }
-  }
+  ]
 }

--- a/models/event-availableFrom.json
+++ b/models/event-availableFrom.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/event-availableTo.json
+++ b/models/event-availableTo.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/event-bookingInfo.json
+++ b/models/event-bookingInfo.json
@@ -23,14 +23,14 @@
       "type": "object",
       "description": "Call-to-action text to show for the link to the booking url",
       "minProperties": 1,
-      "x-examples": {
-        "Example": {
+      "examples": [
+        {
           "nl": "Nederlandse tekst",
           "fr": "Texte français",
           "de": "Deutscher Text",
           "en": "English text"
         }
-      },
+      ],
       "properties": {
         "nl": {
           "type": "string",
@@ -59,20 +59,29 @@
       "type": "string",
       "format": "date-time",
       "example": "2021-05-17T22:00:00+00:00",
-      "minLength": 1,
-      "x-examples": {
-        "Example": "2021-05-17T22:00:00+00:00"
-      }
+      "minLength": 1
     },
     "availabilityEnds": {
       "description": "The date & time when the booking period ends",
       "type": "string",
       "format": "date-time",
       "example": "2021-05-17T22:00:00+00:00",
-      "minLength": 1,
-      "x-examples": {
-        "Example": "2021-05-17T22:00:00+00:00"
-      }
+      "minLength": 1
     }
-  }
+  },
+  "examples": [
+    {
+      "phone": "string",
+      "email": "info@example.com",
+      "url": "https://www.example.com",
+      "urlLabel": {
+        "nl": "Nederlandse tekst",
+        "fr": "Texte français",
+        "de": "Deutscher Text",
+        "en": "English text"
+      },
+      "availabilityStarts": "2021-05-17T22:00:00+00:00",
+      "availabilityEnds": "2021-05-17T22:00:00+00:00"
+    }
+  ]
 }

--- a/models/event-bookingInfo.json
+++ b/models/event-bookingInfo.json
@@ -71,7 +71,7 @@
   },
   "examples": [
     {
-      "phone": "string",
+      "phone": "+32/01234567890",
       "email": "info@example.com",
       "url": "https://www.example.com",
       "urlLabel": {

--- a/models/event-calendarType.json
+++ b/models/event-calendarType.json
@@ -7,5 +7,8 @@
     "multiple",
     "periodic",
     "permanent"
+  ],
+  "examples": [
+    "single"
   ]
 }

--- a/models/event-calendarType.json
+++ b/models/event-calendarType.json
@@ -1,12 +1,11 @@
 {
   "type": "string",
   "title": "event.calendarType",
-  "description": "Determines how often the [event](./event.json) occurs.\n\nPossible values: `single`, `multiple`, `periodic`, `permanent`.\n\n## single\n\nFor events that take place at one single day (f.e. a concert of Radiohead) and events with only one start and end date (f.e. camping from monday until sunday).\n\n**Must** be combined with [startDate](./event-startDate.json) and [endDate](./event-endDate.json).\n\nCan have 1 [subEvent](./event-subEvent.json).\n\n## multiple\n\nFor events that take place on several occasions, whether or not contiguous (f.e. a festival).\n\n**Must** be combined with [startDate](./event-startDate.json) and [endDate](./event-endDate.json).\n\n**Must** have 2+ [subEvents](./event-subEvent.json).\n\n## periodic\n\nFor events that take places on recurring moments (f.e. a course watercolor painting, each wednesday evening).\n\n**Must** be combined with [startDate](./event-startDate.json) and [endDate](./event-endDate.json).\n\nCan be combined with [openingHours](./event-openingHours.json).\n\n## permanent\n\nNot recommended for events, consider creating a [place](./place.json) instead.\n\nCan be combined with [openingHours](./event-openingHours.json).",
+  "description": "Determines how often the [event](./event.json) occurs.\n\nPossible values: `single`, `multiple`, `periodic`, `permanent`.\n\n- **single**: For events that take place at one single day (f.e. a concert of Radiohead) and events with only one start and end date (f.e. camping from monday until sunday). **Must** have 1 [subEvent](./event-subEvent.json). Will automatically get a [startDate](./event-startDate.json) and [endDate](./event-endDate.json) based on the `subEvent`.\n\n- **multiple**: For events that take place on several occasions, whether or not contiguous (f.e. a festival). **Must** have 2+ [subEvents](./event-subEvent.json). Will automatically get a [startDate](./event-startDate.json) and [endDate](./event-endDate.json) based on the `subEvents`.\n\n- **periodic**: For events that take places on recurring moments (f.e. a course watercolor painting, each wednesday evening). **Must** have a [startDate](./event-startDate.json) and [endDate](./event-endDate.json). Can optionally have [openingHours](./event-openingHours.json).\n\n- **permanent**: Not recommended for events, consider creating a [place](./place.json) instead. Can optionally have [openingHours](./event-openingHours.json).",
   "enum": [
     "single",
     "multiple",
     "periodic",
     "permanent"
-  ],
-  "x-examples": {}
+  ]
 }

--- a/models/event-completedLanguages.json
+++ b/models/event-completedLanguages.json
@@ -11,5 +11,11 @@
       "en"
     ],
     "example": "nl"
-  }
+  },
+  "examples": [
+    [
+      "nl",
+      "fr"
+    ]
+  ]
 }

--- a/models/event-contactPoint.json
+++ b/models/event-contactPoint.json
@@ -39,5 +39,18 @@
     "phone",
     "email",
     "url"
+  ],
+  "examples": [
+    {
+      "phone": [
+        "+32/1234567890"
+      ],
+      "email": [
+        "info@example.com"
+      ],
+      "url": [
+        "https://www.example.com"
+      ]
+    }
   ]
 }

--- a/models/event-created.json
+++ b/models/event-created.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/event-creator.json
+++ b/models/event-creator.json
@@ -1,5 +1,8 @@
 {
   "title": "event.creator",
   "type": "string",
-  "description": "The unique identifier of the creator of the [event](./event.json). Usually a UUID, but can historally be an e-mail address.\n\nAdded automatically by UiTdatabank based on the authentication credentials used to create the event."
+  "description": "The unique identifier of the creator of the [event](./event.json). Usually a UUID, but can historally be an e-mail address.\n\nAdded automatically by UiTdatabank based on the authentication credentials used to create the event.",
+  "examples": [
+    "auth0|CE1423AC-655C-4025-86E5-247E06164C85"
+  ]
 }

--- a/models/event-description.json
+++ b/models/event-description.json
@@ -3,14 +3,14 @@
   "description": "A human-readable, localized description of the [event](./event.json). \n\nRequires at least one value, for the language specified in the [mainLanguage](./event-mainLanguage.json) property.",
   "type": "object",
   "minProperties": 1,
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "nl": "Nederlandse tekst",
       "fr": "Texte français",
       "de": "Deutscher Text",
       "en": "English text"
     }
-  },
+  ],
   "properties": {
     "nl": {
       "type": "string",

--- a/models/event-endDate.json
+++ b/models/event-endDate.json
@@ -5,7 +5,7 @@
   "minLength": 1,
   "description": "The date & time that the [event](./event.json) or [subEvent](./event-subEvent.json) ends, as an ISO-8601 date. For example `2021-05-17T22:00:00+00:00`.\n\nRequired on events when using one of the following calendarTypes:\n\n- `single`\n- `multiple`\n- `periodic`\n\nAlways required on subEvents.",
   "title": "event.endDate",
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/event-hiddenLabels.json
+++ b/models/event-hiddenLabels.json
@@ -11,5 +11,12 @@
     "minLength": 2,
     "maxLength": 50,
     "pattern": "^[A-Za-z0-9-_]+"
-  }
+  },
+  "examples": [
+    [
+      "label1",
+      "label2",
+      "label3"
+    ]
+  ]
 }

--- a/models/event-hiddenLabels.json
+++ b/models/event-hiddenLabels.json
@@ -4,7 +4,6 @@
   "description": "Same as [labels](./event-labels.json), but for labels that should not be visible for end users on publication channels and should instead only be used for filtering or other processing.",
   "uniqueItems": true,
   "minItems": 1,
-  "x-examples": {},
   "items": {
     "type": "string",
     "format": "uri",

--- a/models/event-image.json
+++ b/models/event-image.json
@@ -3,5 +3,8 @@
   "title": "event.image",
   "description": "URL to the main image of the [event](./event.json). Must be one of the available `contentUrl` properties in the [mediaObject](./event-mediaObject.json) property.",
   "format": "uri",
-  "example": "https://io-test.uitdatabank.be/images/example.png"
+  "example": "https://io-test.uitdatabank.be/images/example.png",
+  "examples": [
+    "https://io-test.uitdatabank.be/images/example.png"
+  ]
 }

--- a/models/event-labels.json
+++ b/models/event-labels.json
@@ -4,7 +4,6 @@
   "description": "One or more labels that categorize the [event](./event.json). Compared to [terms](./event-terms.json), labels do not have a defined set of possible values or a hierarchy.\n\nLabels are allowed to be visible for end users on publication channels.\n\nSee [hiddenLabels](./event-hiddenLabels.json) for labels that should not be visible on publication channels.",
   "uniqueItems": true,
   "minItems": 1,
-  "x-examples": {},
   "items": {
     "type": "string",
     "format": "uri",

--- a/models/event-labels.json
+++ b/models/event-labels.json
@@ -11,5 +11,12 @@
     "minLength": 2,
     "maxLength": 50,
     "pattern": "^[A-Za-z0-9-_]+"
-  }
+  },
+  "examples": [
+    [
+      "label1",
+      "label2",
+      "label3"
+    ]
+  ]
 }

--- a/models/event-languages.json
+++ b/models/event-languages.json
@@ -11,5 +11,13 @@
       "en"
     ],
     "example": "nl"
-  }
+  },
+  "examples": [
+    [
+      "nl",
+      "fr",
+      "de",
+      "en"
+    ]
+  ]
 }

--- a/models/event-mainLanguage.json
+++ b/models/event-mainLanguage.json
@@ -8,5 +8,8 @@
     "de",
     "en"
   ],
-  "example": "nl"
+  "example": "nl",
+  "examples": [
+    "nl"
+  ]
 }

--- a/models/event-mediaObject.json
+++ b/models/event-mediaObject.json
@@ -3,8 +3,8 @@
   "title": "event.mediaObject",
   "description": "A list of media objects related to the [event](./event.json), for example images.",
   "minItems": 1,
-  "x-examples": {
-    "Example": [
+  "examples": [
+    [
       {
         "@id": "https://io.uitdatabank.be/images/85b04295-479c-40f5-b3dd-469dfb4387b3",
         "@type": "schema:ImageObject",
@@ -15,7 +15,7 @@
         "language": "nl"
       }
     ]
-  },
+  ],
   "items": {
     "type": "object",
     "properties": {
@@ -26,9 +26,9 @@
         "example": "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3",
         "description": "A unique URI that acts as globally unique ID for the media object. Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",
         "readOnly": true,
-        "x-examples": {
-          "Event example": "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3"
-        }
+        "examples": [
+          "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3"
+        ]
       },
       "@type": {
         "type": "string",

--- a/models/event-modified.json
+++ b/models/event-modified.json
@@ -5,7 +5,7 @@
   "minLength": 1,
   "title": "event.modified",
   "description": "Date formatted as an ISO-8601 datetime, added automatically by UiTdatabank based on the date & time the [event](./event.json) was last modified.\n\nFor example `2021-05-17T22:00:00+00:00`.",
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/event-name.json
+++ b/models/event-name.json
@@ -3,14 +3,14 @@
   "description": "The human-readable, localized name of the [event](./event.json). \n\nRequires at least one value, for the language specified in the [mainLanguage](./event-mainLanguage.json) property.",
   "type": "object",
   "minProperties": 1,
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "nl": "Nederlandse tekst",
       "fr": "Texte français",
       "de": "Deutscher Text",
       "en": "English text"
     }
-  },
+  ],
   "properties": {
     "nl": {
       "type": "string",

--- a/models/event-openingHours.json
+++ b/models/event-openingHours.json
@@ -4,8 +4,8 @@
   "items": {
     "type": "object",
     "description": "Indicates the weekly start and end times of a `periodic` event.",
-    "x-examples": {
-      "Example": {
+    "examples": [
+      {
         "opens": "09:00",
         "closes": "17:00",
         "dayOfWeek": [
@@ -16,7 +16,7 @@
           "friday"
         ]
       }
-    },
+    ],
     "properties": {
       "opens": {
         "type": "string",
@@ -24,9 +24,9 @@
         "description": "A string in the format of ISO-8601 hour and minutes, representing an opening- or closing time. For example `17:00`.",
         "example": "17:00",
         "format": "time",
-        "x-examples": {
-          "Example": "17:00"
-        }
+        "examples": [
+          "17:00"
+        ]
       },
       "closes": {
         "type": "string",
@@ -34,9 +34,9 @@
         "description": "A string in the format of ISO-8601 hour and minutes, representing an opening- or closing time. For example `17:00`.",
         "example": "17:00",
         "format": "time",
-        "x-examples": {
-          "Example": "17:00"
-        }
+        "examples": [
+          "17:00"
+        ]
       },
       "dayOfWeek": {
         "type": "array",

--- a/models/event-openingHours.json
+++ b/models/event-openingHours.json
@@ -64,5 +64,28 @@
       "dayOfWeek"
     ]
   },
-  "description": "A list of opening hour entries indicating the weekly start and end times of the [event](./event.json) when using the `periodic` [calendarType](./event-calendarType.json)."
+  "description": "A list of opening hour entries indicating the weekly start and end times of the [event](./event.json) when using the `periodic` [calendarType](./event-calendarType.json).",
+  "examples": [
+    [
+      {
+        "opens": "13:00",
+        "closes": "17:00",
+        "dayOfWeek": [
+          "monday"
+        ]
+      },
+      {
+        "opens": "09:00",
+        "closes": "17:00",
+        "dayOfWeek": [
+          "tuesday",
+          "wednesday",
+          "thursday",
+          "friday",
+          "saturday",
+          "sunday"
+        ]
+      }
+    ]
+  ]
 }

--- a/models/event-organizer.json
+++ b/models/event-organizer.json
@@ -1,5 +1,5 @@
 {
   "$ref": "./organizer.json",
   "title": "event.organizer",
-  "description": "The organizer of the [event](./event.json). Links to another entity, but also embeds it. Same model as an [organizer](./organizer.json)."
+  "description": "The organizer of the [event](./event.json). Links to another entity, but also embeds it automatically. Same model as an [organizer](./organizer.json)."
 }

--- a/models/event-priceInfo.json
+++ b/models/event-priceInfo.json
@@ -2,21 +2,8 @@
   "type": "array",
   "title": "event.priceInfo",
   "description": "A list of tariffs available for tickets to the [event](./event.json).",
-  "x-examples": {
-    "Base tariff only": [
-      {
-        "category": "base",
-        "price": 10.5,
-        "priceCurrency": "EUR",
-        "name": {
-          "nl": "Basistarief",
-          "fr": "Tarif de base",
-          "en": "Base tariff",
-          "de": "Basisrate"
-        }
-      }
-    ],
-    "Multiple tariffs": [
+  "examples": [
+    [
       {
         "category": "base",
         "price": 10.5,
@@ -38,32 +25,10 @@
         }
       }
     ]
-  },
+  ],
   "minItems": 1,
   "items": {
     "type": "object",
-    "x-examples": {
-      "Base tariff": {
-        "category": "base",
-        "price": 10.5,
-        "priceCurrency": "EUR",
-        "name": {
-          "nl": "Basistarief",
-          "fr": "Tarif de base",
-          "en": "Base tariff",
-          "de": "Basisrate"
-        }
-      },
-      "Custom tariff": {
-        "category": "tariff",
-        "price": 6,
-        "priceCurrency": "EUR",
-        "name": {
-          "nl": "Jongeren (<18j)",
-          "en": "Youth (<18yo)"
-        }
-      }
-    },
     "description": "A single priceInfo item.",
     "properties": {
       "category": {
@@ -93,18 +58,6 @@
         "description": "Name of a tariff inside priceInfo. Requires at least one value, for the language specified in the `mainLanguage` property.",
         "type": "object",
         "minProperties": 1,
-        "x-examples": {
-          "Base tariff": {
-            "nl": "Basistarief",
-            "fr": "Tarif de base",
-            "en": "Base tariff",
-            "de": "Basisrate"
-          },
-          "Youth": {
-            "nl": "Jongeren (<18j)",
-            "en": "Youth (<18yo)"
-          }
-        },
         "properties": {
           "nl": {
             "type": "string",

--- a/models/event-production.json
+++ b/models/event-production.json
@@ -1,8 +1,8 @@
 {
   "description": "The production that the [event](./event.json) belongs to.\n\nA production is a group of events that share the same subject but are taking place in different locations and/or are organized by different organizers.\n\nFor example a theatre show that is scheduled to be performed at different locations, or a movie that will be screened at different cinema's.",
   "type": "object",
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "id": "10ce7cb1-7bc9-4ce4-a256-460f56c49965",
       "title": "Kommil Foo - OOGST",
       "otherEvents": [
@@ -10,7 +10,7 @@
         "https://io.uitdatabank.be/events/eb155497-46b9-4fb2-9457-d073fe02322e"
       ]
     }
-  },
+  ],
   "title": "event.production",
   "properties": {
     "id": {

--- a/models/event-sameAs.json
+++ b/models/event-sameAs.json
@@ -4,11 +4,11 @@
   "description": "One or more URIs that represent the same [event](./event.json) on another API or website, not necessarily in JSON-LD format.\n\nAdded automatically by UiTdatabank based on info from other systems.\n\nFor example `http://www.uitinvlaanderen.be/agenda/e/test-event/85b04295-479c-40f5-b3dd-469dfb4387b3`.",
   "uniqueItems": true,
   "minItems": 1,
-  "x-examples": {
-    "UiTinVlaanderen Example": [
+  "examples": [
+    [
       "http://www.uitinvlaanderen.be/agenda/e/test-event/85b04295-479c-40f5-b3dd-469dfb4387b3"
     ]
-  },
+  ],
   "items": {
     "type": "string",
     "format": "uri",

--- a/models/event-startDate.json
+++ b/models/event-startDate.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/event-status.json
+++ b/models/event-status.json
@@ -2,24 +2,24 @@
   "title": "event.status",
   "type": "object",
   "description": "Indicates if the [event](./event.json) is still happening as scheduled or not.",
-  "x-examples": {
-    "Available": {
+  "examples": [
+    {
       "type": "Available"
     },
-    "Temporarily Unavailable": {
+    {
       "type": "TemporarilyUnavailable",
       "reason": {
         "nl": "Uitgesteld wegens covid-19",
         "en": "Postponed due to covid-19"
       }
     },
-    "Unavailable": {
+    {
       "type": "Unavailable",
       "reason": {
         "nl": "Permanent gesloten"
       }
     }
-  },
+  ],
   "properties": {
     "type": {
       "type": "string",
@@ -37,14 +37,6 @@
       "title": "",
       "type": "object",
       "minProperties": 1,
-      "x-examples": {
-        "Example": {
-          "nl": "Nederlandse tekst",
-          "fr": "Texte français",
-          "de": "Deutscher Text",
-          "en": "English text"
-        }
-      },
       "properties": {
         "nl": {
           "type": "string",

--- a/models/event-subEvent.json
+++ b/models/event-subEvent.json
@@ -4,15 +4,15 @@
   "description": "A list of occurences of the [event](./event.json) when using the `single` or `multiple` [calendarType](./event-calendarType.json).",
   "items": {
     "type": "object",
-    "x-examples": {
-      "Available": {
+    "examples": [
+      {
         "startDate": "2021-05-17T16:00:00+00:00",
         "endDate": "2021-05-17T22:00:00+00:00",
         "status": {
           "type": "Available"
         }
       },
-      "Temporarily Unavailable": {
+      {
         "startDate": "2021-05-17T16:00:00+00:00",
         "endDate": "2021-05-17T22:00:00+00:00",
         "status": {
@@ -22,7 +22,7 @@
           }
         }
       },
-      "Unavailable": {
+      {
         "startDate": "2021-05-17T16:00:00+00:00",
         "endDate": "2021-05-17T22:00:00+00:00",
         "status": {
@@ -32,7 +32,7 @@
           }
         }
       }
-    },
+    ],
     "properties": {
       "startDate": {
         "$ref": "./event-startDate.json"
@@ -50,8 +50,8 @@
       "status"
     ]
   },
-  "x-examples": {
-    "Single": [
+  "examples": [
+    [
       {
         "startDate": "2021-05-17T16:00:00+00:00",
         "endDate": "2021-05-17T22:00:00+00:00",
@@ -60,7 +60,7 @@
         }
       }
     ],
-    "Multiple": [
+    [
       {
         "startDate": "2021-05-17T16:00:00+00:00",
         "endDate": "2021-05-17T22:00:00+00:00",
@@ -76,5 +76,5 @@
         }
       }
     ]
-  }
+  ]
 }

--- a/models/event-terms.json
+++ b/models/event-terms.json
@@ -8,13 +8,13 @@
     "title": "",
     "type": "object",
     "description": "A taxonomy term used to categorize events.\n\nAll events require exactly one term of the `eventtype` domain, and can optionally contain other terms.\n\nWhen reading events, all properties will be available. When creating or updating events only the `id` is required to be included.",
-    "x-examples": {
-      "Example": {
+    "examples": [
+      {
         "id": "0.50.4.0.0",
         "label": "Concert",
         "domain": "eventtype"
       }
-    },
+    ],
     "properties": {
       "id": {
         "type": "string",

--- a/models/event-terms.json
+++ b/models/event-terms.json
@@ -40,5 +40,14 @@
     "required": [
       "id"
     ]
-  }
+  },
+  "examples": [
+    [
+      {
+        "id": "0.50.4.0.0",
+        "label": "Concert",
+        "domain": "eventtype"
+      }
+    ]
+  ]
 }

--- a/models/event-typicalAgeRange.json
+++ b/models/event-typicalAgeRange.json
@@ -3,9 +3,9 @@
   "title": "event.typicalAgeRange",
   "description": "Indicates the minimum and maximum age to attend the [event](./event.json). For example `6-12`, `0-12`, `-12`, or `6-`.",
   "example": "6-12",
-  "x-examples": {
-    "Min age and max age": "6-12",
-    "Max age": -12,
-    "Min age": "6-"
-  }
+  "examples": [
+    "6-12",
+    "-12",
+    "6-"
+  ]
 }

--- a/models/event-workflowStatus.json
+++ b/models/event-workflowStatus.json
@@ -7,6 +7,5 @@
     "READY_FOR_VALIDATION",
     "APPROVED",
     "DELETED"
-  ],
-  "x-examples": {}
+  ]
 }

--- a/models/event-workflowStatus.json
+++ b/models/event-workflowStatus.json
@@ -7,5 +7,8 @@
     "READY_FOR_VALIDATION",
     "APPROVED",
     "DELETED"
+  ],
+  "examples": [
+    "DRAFT"
   ]
 }

--- a/models/event.json
+++ b/models/event.json
@@ -1,8 +1,8 @@
 {
   "description": "A cultural, sport, or leisure activity.",
   "type": "object",
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "@id": "https://io.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3",
       "mainLanguage": "nl",
       "name": {
@@ -287,7 +287,7 @@
         ]
       }
     }
-  },
+  ],
   "title": "event",
   "properties": {
     "@id": {

--- a/models/place-@id.json
+++ b/models/place-@id.json
@@ -6,7 +6,7 @@
   "example": "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3",
   "description": "A unique URI that acts as globally unique ID for the [place](./place.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",
   "readOnly": true,
-  "x-examples": {
-    "Example": "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3"
-  }
+  "examples": [
+    "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3"
+  ]
 }

--- a/models/place-address.json
+++ b/models/place-address.json
@@ -1,8 +1,8 @@
 {
   "description": "The address the [place](./place.json) is located at. Localized because some parts like the municipality or street address can be different in Dutch, French, German and/or English.\n\nRequires at least one locale, specifically the one defined in the [mainLanguage](./place-mainLanguage.json) of the place.\n\n**Only add a localized version if it's an official variant!**",
   "type": "object",
-  "x-examples": {
-    "Localized example": {
+  "examples": [
+    {
       "nl": {
         "addressCountry": "BE",
         "addressLocality": "Brussel",
@@ -16,7 +16,7 @@
         "streetAddress": "Rue de la Loi 1"
       }
     }
-  },
+  ],
   "title": "place.address",
   "properties": {
     "nl": {

--- a/models/place-availableFrom.json
+++ b/models/place-availableFrom.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/place-availableTo.json
+++ b/models/place-availableTo.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/place-bookingInfo.json
+++ b/models/place-bookingInfo.json
@@ -23,14 +23,14 @@
       "type": "object",
       "description": "Call-to-action text to show for the link to the booking url",
       "minProperties": 1,
-      "x-examples": {
-        "Example": {
+      "examples": [
+        {
           "nl": "Nederlandse tekst",
           "fr": "Texte français",
           "de": "Deutscher Text",
           "en": "English text"
         }
-      },
+      ],
       "properties": {
         "nl": {
           "type": "string",
@@ -60,9 +60,9 @@
       "format": "date-time",
       "example": "2021-05-17T22:00:00+00:00",
       "minLength": 1,
-      "x-examples": {
-        "Example": "2021-05-17T22:00:00+00:00"
-      }
+      "examples": [
+        "2021-05-17T22:00:00+00:00"
+      ]
     },
     "availabilityEnds": {
       "description": "The date & time when the booking period ends",
@@ -70,9 +70,9 @@
       "format": "date-time",
       "example": "2021-05-17T22:00:00+00:00",
       "minLength": 1,
-      "x-examples": {
-        "Example": "2021-05-17T22:00:00+00:00"
-      }
+      "examples": [
+        "2021-05-17T22:00:00+00:00"
+      ]
     }
   }
 }

--- a/models/place-bookingInfo.json
+++ b/models/place-bookingInfo.json
@@ -74,5 +74,20 @@
         "2021-05-17T22:00:00+00:00"
       ]
     }
-  }
+  },
+  "examples": [
+    {
+      "phone": "+32/01234567890",
+      "email": "info@example.com",
+      "url": "https://www.example.com",
+      "urlLabel": {
+        "nl": "Nederlandse tekst",
+        "fr": "Texte français",
+        "de": "Deutscher Text",
+        "en": "English text"
+      },
+      "availabilityStarts": "2021-05-17T22:00:00+00:00",
+      "availabilityEnds": "2021-05-17T22:00:00+00:00"
+    }
+  ]
 }

--- a/models/place-calendarType.json
+++ b/models/place-calendarType.json
@@ -5,5 +5,8 @@
   "enum": [
     "periodic",
     "permanent"
+  ],
+  "examples": [
+    "periodic"
   ]
 }

--- a/models/place-calendarType.json
+++ b/models/place-calendarType.json
@@ -1,10 +1,9 @@
 {
   "type": "string",
   "title": "place.calendarType",
-  "description": "Determines how long the [place](./place.json) exists.\n\nPossible values: `periodic`, `permanent`.\n\n## periodic\n\nFor places that only exist for a specific period.\n\n**Must** be combined with [startDate](./place-startDate.json) and [endDate](./place-endDate.json).\n\nCan be combined with [openingHours](./place-openingHours.json).\n\n## permanent\n\nFor places that exist permanently.\n\nCan be combined with [openingHours](./place-openingHours.json).",
+  "description": "Determines how long the [place](./place.json) exists.\n\nPossible values: `periodic`, `permanent`.\n\n- **periodic**: For places that only exist for a specific period. **Must** have a [startDate](./place-startDate.json) and [endDate](./place-endDate.json). Can optionally have [openingHours](./place-openingHours.json).\n\n- **permanent**: For places that exist permanently. Can optionally have [openingHours](./place-openingHours.json).",
   "enum": [
     "periodic",
     "permanent"
-  ],
-  "x-examples": {}
+  ]
 }

--- a/models/place-completedLanguages.json
+++ b/models/place-completedLanguages.json
@@ -11,5 +11,11 @@
       "en"
     ],
     "example": "nl"
-  }
+  },
+  "examples": [
+    [
+      "nl",
+      "fr"
+    ]
+  ]
 }

--- a/models/place-contactPoint.json
+++ b/models/place-contactPoint.json
@@ -39,5 +39,18 @@
     "phone",
     "email",
     "url"
+  ],
+  "examples": [
+    {
+      "phone": [
+        "+32/01234567890"
+      ],
+      "email": [
+        "info@example.com"
+      ],
+      "url": [
+        "https://www.example.com"
+      ]
+    }
   ]
 }

--- a/models/place-created.json
+++ b/models/place-created.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/place-creator.json
+++ b/models/place-creator.json
@@ -1,5 +1,8 @@
 {
   "title": "place.creator",
   "type": "string",
-  "description": "The unique identifier of the creator of the [place](./place.json). Usually a UUID, but can historally be an e-mail address.\n\nAdded automatically by UiTdatabank based on the authentication credentials used to create the place."
+  "description": "The unique identifier of the creator of the [place](./place.json). Usually a UUID, but can historally be an e-mail address.\n\nAdded automatically by UiTdatabank based on the authentication credentials used to create the place.",
+  "examples": [
+    "auth0|CE1423AC-655C-4025-86E5-247E06164C85"
+  ]
 }

--- a/models/place-description.json
+++ b/models/place-description.json
@@ -3,14 +3,14 @@
   "description": "A human-readable, localized description of the [place](./place.json). \n\nRequires at least one value, for the language specified in the [mainLanguage](./place-mainLanguage.json) property.",
   "type": "object",
   "minProperties": 1,
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "nl": "Nederlandse tekst",
       "fr": "Texte français",
       "de": "Deutscher Text",
       "en": "English text"
     }
-  },
+  ],
   "properties": {
     "nl": {
       "type": "string",

--- a/models/place-endDate.json
+++ b/models/place-endDate.json
@@ -5,7 +5,7 @@
   "minLength": 1,
   "description": "The date & time that the [place](./place.json) ends when using the `periodic` [calendarType](./place-calendarType.json), as an ISO-8601 date.\n\nFor example `2021-05-17T22:00:00+00:00`.",
   "title": "place.endDate",
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/place-geo.json
+++ b/models/place-geo.json
@@ -20,10 +20,10 @@
     "latitude",
     "longitude"
   ],
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "latitude": 50.8816177,
       "longitude": 4.7137986
     }
-  }
+  ]
 }

--- a/models/place-hiddenLabels.json
+++ b/models/place-hiddenLabels.json
@@ -11,5 +11,12 @@
     "minLength": 2,
     "maxLength": 50,
     "pattern": "^[A-Za-z0-9-_]+"
-  }
+  },
+  "examples": [
+    [
+      "label1",
+      "label2",
+      "label3"
+    ]
+  ]
 }

--- a/models/place-hiddenLabels.json
+++ b/models/place-hiddenLabels.json
@@ -4,7 +4,6 @@
   "description": "Same as [labels](./place-labels.json), but for labels that should not be visible for end users on publication channels and should instead only be used for filtering or other processing.",
   "uniqueItems": true,
   "minItems": 1,
-  "x-examples": {},
   "items": {
     "type": "string",
     "format": "uri",

--- a/models/place-image.json
+++ b/models/place-image.json
@@ -3,5 +3,8 @@
   "title": "place.image",
   "description": "URL to the main image of the [place](./place.json). Must be one of the available `contentUrl` properties in the [mediaObject](./place-mediaObject.json) property.",
   "format": "uri",
-  "example": "https://io-test.uitdatabank.be/images/example.png"
+  "example": "https://io-test.uitdatabank.be/images/example.png",
+  "examples": [
+    "https://io-test.uitdatabank.be/images/example.png"
+  ]
 }

--- a/models/place-labels.json
+++ b/models/place-labels.json
@@ -11,5 +11,12 @@
     "maxLength": 50,
     "pattern": "^[A-Za-z0-9-_]+",
     "example": "label1"
-  }
+  },
+  "examples": [
+    [
+      "label1",
+      "label2",
+      "label3"
+    ]
+  ]
 }

--- a/models/place-labels.json
+++ b/models/place-labels.json
@@ -4,7 +4,6 @@
   "description": "One or more labels that categorize the [place](./place.json). Compared to [terms](./place-terms.json), labels do not have a defined set of possible values or a hierarchy.\n\nLabels are allowed to be visible for end users on publication channels.\n\nSee [hiddenLabels](./place-hiddenLabels.json) for labels that should not be visible on publication channels.",
   "uniqueItems": true,
   "minItems": 1,
-  "x-examples": {},
   "items": {
     "type": "string",
     "format": "uri",

--- a/models/place-languages.json
+++ b/models/place-languages.json
@@ -11,5 +11,13 @@
       "en"
     ],
     "example": "nl"
-  }
+  },
+  "examples": [
+    [
+      "nl",
+      "fr",
+      "de",
+      "en"
+    ]
+  ]
 }

--- a/models/place-mainLanguage.json
+++ b/models/place-mainLanguage.json
@@ -8,5 +8,8 @@
     "de",
     "en"
   ],
-  "example": "nl"
+  "example": "nl",
+  "examples": [
+    "nl"
+  ]
 }

--- a/models/place-mediaObject.json
+++ b/models/place-mediaObject.json
@@ -3,8 +3,8 @@
   "title": "place.mediaObject",
   "description": "A list of media objects related to the [place](./place.json), for example images.",
   "minItems": 1,
-  "x-examples": {
-    "Example": [
+  "examples": [
+    [
       {
         "@id": "https://io.uitdatabank.be/images/85b04295-479c-40f5-b3dd-469dfb4387b3",
         "@type": "schema:ImageObject",
@@ -15,7 +15,7 @@
         "language": "nl"
       }
     ]
-  },
+  ],
   "items": {
     "type": "object",
     "properties": {
@@ -26,9 +26,9 @@
         "example": "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3",
         "description": "A unique URI that acts as globally unique ID for the media object. Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",
         "readOnly": true,
-        "x-examples": {
-          "Event example": "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3"
-        }
+        "examples": [
+          "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3"
+        ]
       },
       "@type": {
         "type": "string",

--- a/models/place-modified.json
+++ b/models/place-modified.json
@@ -5,7 +5,7 @@
   "minLength": 1,
   "title": "place.modified",
   "description": "Date formatted as an ISO-8601 datetime, added automatically by UiTdatabank based on the date & time the [place](./place.json) was last modified.\n\nFor example `2021-05-17T22:00:00+00:00`.",
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/place-name.json
+++ b/models/place-name.json
@@ -3,14 +3,14 @@
   "description": "The human-readable, localized name of the [place](./place.json). \n\nRequires at least one value, for the language specified in the [mainLanguage](./place-mainLanguage.json) property.",
   "type": "object",
   "minProperties": 1,
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "nl": "Nederlandse tekst",
       "fr": "Texte français",
       "de": "Deutscher Text",
       "en": "English text"
     }
-  },
+  ],
   "properties": {
     "nl": {
       "type": "string",

--- a/models/place-openingHours.json
+++ b/models/place-openingHours.json
@@ -64,5 +64,28 @@
       "dayOfWeek"
     ]
   },
-  "description": "A list of opening hour entries indicating the weekly opening and closing hours of the [place](./place.json)."
+  "description": "A list of opening hour entries indicating the weekly opening and closing hours of the [place](./place.json).",
+  "examples": [
+    [
+      {
+        "opens": "13:00",
+        "closes": "17:00",
+        "dayOfWeek": [
+          "monday"
+        ]
+      },
+      {
+        "opens": "09:00",
+        "closes": "17:00",
+        "dayOfWeek": [
+          "tuesday",
+          "wednesday",
+          "thursday",
+          "friday",
+          "saturday",
+          "sunday"
+        ]
+      }
+    ]
+  ]
 }

--- a/models/place-openingHours.json
+++ b/models/place-openingHours.json
@@ -4,8 +4,8 @@
   "items": {
     "type": "object",
     "description": "Indicates the weekly start and end times of a `periodic` place.",
-    "x-examples": {
-      "Example": {
+    "examples": [
+      {
         "opens": "09:00",
         "closes": "17:00",
         "dayOfWeek": [
@@ -16,7 +16,7 @@
           "friday"
         ]
       }
-    },
+    ],
     "properties": {
       "opens": {
         "type": "string",
@@ -24,9 +24,9 @@
         "description": "A string in the format of ISO-8601 hour and minutes, representing an opening- or closing time. For example `17:00`.",
         "example": "17:00",
         "format": "time",
-        "x-examples": {
-          "Example": "17:00"
-        }
+        "examples": [
+          "17:00"
+        ]
       },
       "closes": {
         "type": "string",
@@ -34,9 +34,9 @@
         "description": "A string in the format of ISO-8601 hour and minutes, representing an opening- or closing time. For example `17:00`.",
         "example": "17:00",
         "format": "time",
-        "x-examples": {
-          "Example": "17:00"
-        }
+        "examples": [
+          "17:00"
+        ]
       },
       "dayOfWeek": {
         "type": "array",

--- a/models/place-organizer.json
+++ b/models/place-organizer.json
@@ -1,5 +1,5 @@
 {
-  "$ref": "../organizer.json",
+  "$ref": "./organizer.json",
   "title": "place.organizer",
-  "description": "The organizer of the [place](./place.json). Links to another entity, but also embeds it. Same model as an [organizer](../organizer.json)."
+  "description": "The organizer of the [place](./place.json). Links to another entity, but also embeds it automatically. Same model as an [organizer](./organizer.json)."
 }

--- a/models/place-priceInfo.json
+++ b/models/place-priceInfo.json
@@ -2,8 +2,8 @@
   "type": "array",
   "title": "place.priceInfo",
   "description": "A list of tariffs available for tickets to the [place](./place.json).",
-  "x-examples": {
-    "Base tariff only": [
+  "examples": [
+    [
       {
         "category": "base",
         "price": 10.5,
@@ -16,7 +16,7 @@
         }
       }
     ],
-    "Multiple tariffs": [
+    [
       {
         "category": "base",
         "price": 10.5,
@@ -38,12 +38,12 @@
         }
       }
     ]
-  },
+  ],
   "minItems": 1,
   "items": {
     "type": "object",
-    "x-examples": {
-      "Base tariff": {
+    "examples": [
+      {
         "category": "base",
         "price": 10.5,
         "priceCurrency": "EUR",
@@ -54,7 +54,7 @@
           "de": "Basisrate"
         }
       },
-      "Custom tariff": {
+      {
         "category": "tariff",
         "price": 6,
         "priceCurrency": "EUR",
@@ -63,7 +63,7 @@
           "en": "Youth (<18yo)"
         }
       }
-    },
+    ],
     "description": "A single priceInfo item.",
     "properties": {
       "category": {
@@ -93,18 +93,18 @@
         "description": "Name of a tariff inside priceInfo. Requires at least one value, for the language specified in the `mainLanguage` property.",
         "type": "object",
         "minProperties": 1,
-        "x-examples": {
-          "Base tariff": {
+        "examples": [
+          {
             "nl": "Basistarief",
             "fr": "Tarif de base",
             "en": "Base tariff",
             "de": "Basisrate"
           },
-          "Youth": {
+          {
             "nl": "Jongeren (<18j)",
             "en": "Youth (<18yo)"
           }
-        },
+        ],
         "properties": {
           "nl": {
             "type": "string",

--- a/models/place-sameAs.json
+++ b/models/place-sameAs.json
@@ -4,11 +4,11 @@
   "description": "One or more URIs that represent the same [place](./place.json) on another API or website, not necessarily in JSON-LD format.\n\nAdded automatically by UiTdatabank based on info from other systems.\n\nFor example `http://www.uitinvlaanderen.be/agenda/p/test-place/85b04295-479c-40f5-b3dd-469dfb4387b3`.",
   "uniqueItems": true,
   "minItems": 1,
-  "x-examples": {
-    "UiTinVlaanderen Example": [
+  "examples": [
+    [
       "http://www.uitinvlaanderen.be/agenda/e/test-place/85b04295-479c-40f5-b3dd-469dfb4387b3"
     ]
-  },
+  ],
   "items": {
     "type": "string",
     "format": "uri",

--- a/models/place-startDate.json
+++ b/models/place-startDate.json
@@ -5,7 +5,7 @@
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
   "minLength": 1,
-  "x-examples": {
-    "Example": "2021-05-17T22:00:00+00:00"
-  }
+  "examples": [
+    "2021-05-17T22:00:00+00:00"
+  ]
 }

--- a/models/place-status.json
+++ b/models/place-status.json
@@ -2,24 +2,24 @@
   "title": "place.status",
   "type": "object",
   "description": "Indicates if the [place](./place.json) is still open for visitations or not.",
-  "x-examples": {
-    "Available": {
+  "examples": [
+    {
       "type": "Available"
     },
-    "Temporarily Unavailable": {
+    {
       "type": "TemporarilyUnavailable",
       "reason": {
         "nl": "Uitgesteld wegens covid-19",
         "en": "Postponed due to covid-19"
       }
     },
-    "Unavailable": {
+    {
       "type": "Unavailable",
       "reason": {
         "nl": "Permanent gesloten"
       }
     }
-  },
+  ],
   "properties": {
     "type": {
       "minLength": 1,
@@ -37,14 +37,14 @@
       "title": "",
       "type": "object",
       "minProperties": 1,
-      "x-examples": {
-        "Example": {
+      "examples": [
+        {
           "nl": "Nederlandse tekst",
           "fr": "Texte français",
           "de": "Deutscher Text",
           "en": "English text"
         }
-      },
+      ],
       "properties": {
         "nl": {
           "type": "string",

--- a/models/place-terms.json
+++ b/models/place-terms.json
@@ -8,13 +8,13 @@
     "title": "",
     "type": "object",
     "description": "A taxonomy term used to categorize places.\n\nAll places require exactly one term of the `placetype` domain, and can optionally contain other terms.\n\nWhen reading places, all properties will be available. When creating or updating places only the `id` is required to be included.",
-    "x-examples": {
-      "Example": {
+    "examples": [
+      {
         "id": "0.50.4.0.0",
         "label": "Concert",
         "domain": "placetype"
       }
-    },
+    ],
     "properties": {
       "id": {
         "type": "string",

--- a/models/place-terms.json
+++ b/models/place-terms.json
@@ -40,5 +40,14 @@
     "required": [
       "id"
     ]
-  }
+  },
+  "examples": [
+    [
+      {
+        "id": "0.50.4.0.0",
+        "label": "Concert",
+        "domain": "placetype"
+      }
+    ]
+  ]
 }

--- a/models/place-typicalAgeRange.json
+++ b/models/place-typicalAgeRange.json
@@ -3,9 +3,9 @@
   "title": "place.typicalAgeRange",
   "description": "Indicates the minimum and maximum age to visit the [place](./place.json). For example `6-12`, `0-12`, `-12`, or `6-`.",
   "example": "6-12",
-  "x-examples": {
-    "Min age and max age": "6-12",
-    "Max age": -12,
-    "Min age": "6-"
-  }
+  "examples": [
+    "6-12",
+    "-12",
+    "6-"
+  ]
 }

--- a/models/place-workflowStatus.json
+++ b/models/place-workflowStatus.json
@@ -7,6 +7,5 @@
     "READY_FOR_VALIDATION",
     "APPROVED",
     "DELETED"
-  ],
-  "x-examples": {}
+  ]
 }

--- a/models/place-workflowStatus.json
+++ b/models/place-workflowStatus.json
@@ -7,5 +7,8 @@
     "READY_FOR_VALIDATION",
     "APPROVED",
     "DELETED"
+  ],
+  "examples": [
+    "DRAFT"
   ]
 }

--- a/models/place.json
+++ b/models/place.json
@@ -107,8 +107,8 @@
     "languages",
     "completedLanguages"
   ],
-  "x-examples": {
-    "Example": {
+  "examples": [
+    {
       "@id": "https://io.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3",
       "mainLanguage": "nl",
       "name": {
@@ -253,5 +253,5 @@
         "label2"
       ]
     }
-  }
+  ]
 }


### PR DESCRIPTION
### Fixed

- Fixed examples in event/place models that were broken in the new Stoplight Studio because they now use `examples` instead of `x-examples` which was not standard JSON schema. (Sadly we lose the example names with this change though)

