### PR TITLE
III-4429 Add docs for patch endpoint of organizer

### DIFF
--- a/models/organizer-patch.json
+++ b/models/organizer-patch.json
@@ -9,7 +9,7 @@
   ],
   "minProperties": 1,
   "properties": {
-    "mainImage": {
+    "mainImageId": {
       "type": "string",
       "format": "uuid",
       "example": "4b349765-9499-4d35-b295-c82ede576cf0",

--- a/models/organizer-patch.json
+++ b/models/organizer-patch.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "title": "organizer-patch",
+  "description": "",
+  "examples": [
+    {
+      "mainImage": "4b349765-9499-4d35-b295-c82ede576cf0"
+    }
+  ],
+  "minProperties": 1,
+  "properties": {
+    "mainImage": {
+      "type": "string",
+      "format": "uuid",
+      "example": "4b349765-9499-4d35-b295-c82ede576cf0",
+      "description": "The id of the image to set as main image on the organizer."
+    }
+  }
+}

--- a/models/organizer.json
+++ b/models/organizer.json
@@ -70,7 +70,7 @@
           }
         ]
       ],
-      "image": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
+      "mainImage": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
       "labels": [
         "label1",
         "label2"

--- a/models/organizer.json
+++ b/models/organizer.json
@@ -58,7 +58,7 @@
           "https://www.publiq.be"
         ]
       },
-      "examples": [
+      "images": [
         [
           {
             "@id": "https://io.uitdatabank.be/images/546a90cd-a238-417b-aa98-1b6c50c1345c",

--- a/models/organizer.json
+++ b/models/organizer.json
@@ -127,7 +127,7 @@
     "images": {
       "$ref": "./organizer-images.json"
     },
-    "image": {
+    "mainImage": {
       "type": "string",
       "format": "url",
       "example": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -2850,6 +2850,63 @@
           }
         ],
         "x-internal": true
+      },
+      "patch": {
+        "summary": "Patch organizer",
+        "operationId": "patch-organizer",
+        "responses": {
+          "204": {
+            "description": "The organizer was updated."
+          },
+          "400": {
+            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/OrganizerNotFound"
+          }
+        },
+        "description": "Update one or more properties of an organizer. For now only the `mainImage` property is supported.",
+        "security": [
+          {
+            "USER_ACCESS_TOKEN": []
+          },
+          {
+            "CLIENT_ACCESS_TOKEN": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "../models/organizer-patch.json"
+              },
+              "examples": {
+                "Update the main image": {
+                  "value": {
+                    "mainImage": "4b349765-9499-4d35-b295-c82ede576cf0"
+                  }
+                }
+              }
+            }
+          },
+          "description": ""
+        },
+        "tags": [
+          "Organizers"
+        ]
       }
     },
     "/organizers/{organizerId}/contact-point": {


### PR DESCRIPTION
### Added
- Added docs for patch endpoint of organizer (for now only `mainImageId` is supported)

### Notes:
- Setting the main image requires an id, because of this for the patch `mainImageId` is chosen as name.
- The projection is a Url and because of this the more general name `mainImage` is chosen.

---
Ticket: https://jira.uitdatabank.be/browse/III-4429
