### PR TITLE
Tweak news article documentation

### DIFF
--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3768,7 +3768,7 @@
           }
         ],
         "tags": [
-          "News Articles"
+          "News articles"
         ]
       },
       "post": {
@@ -3798,7 +3798,7 @@
           }
         },
         "tags": [
-          "News Articles"
+          "News articles"
         ]
       }
     },
@@ -3843,7 +3843,7 @@
         },
         "x-internal": true,
         "tags": [
-          "News Articles"
+          "News articles"
         ]
       },
       "delete": {
@@ -3857,7 +3857,7 @@
         "description": "Delete a news article with the given article id.",
         "x-internal": true,
         "tags": [
-          "News Articles"
+          "News articles"
         ]
       },
       "put": {
@@ -3890,7 +3890,7 @@
           }
         },
         "tags": [
-          "News Articles"
+          "News articles"
         ]
       }
     }

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3678,9 +3678,9 @@
     },
     "/news_articles": {
       "get": {
-        "summary": "Get All News Article",
-        "description": "Get the details of all News Article matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 News Articles.\nThe extra query parameter `page` can be used to get News Articles after the first 30 results.  ",
-        "operationId": "get-all-news-article",
+        "summary": "Get all news articles",
+        "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.  ",
+        "operationId": "get-all-news-articles",
         "tags": [
           "NewsArticles"
         ],

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -4157,7 +4157,7 @@
       "name": "Events"
     },
     {
-      "name": "News Articles"
+      "name": "News articles"
     },
     {
       "name": "Organizers"

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3809,7 +3809,7 @@
         }
       ],
       "get": {
-        "summary": "Get news article",
+        "summary": "Get a news article",
         "description": "Returns the details of a news article with the given article id.",
         "operationId": "get-news-article",
         "responses": {
@@ -3861,7 +3861,7 @@
         ]
       },
       "put": {
-        "summary": "Update news article",
+        "summary": "Update a news article",
         "operationId": "put-news-article",
         "responses": {
           "200": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3681,9 +3681,6 @@
         "summary": "Get all news articles",
         "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.  ",
         "operationId": "get-all-news-articles",
-        "tags": [
-          "NewsArticles"
-        ],
         "responses": {
           "200": {
             "description": "News Articles details",
@@ -3769,6 +3766,9 @@
             "name": "page",
             "description": "The page the results should start from"
           }
+        ],
+        "tags": [
+          "News Articles"
         ]
       },
       "post": {
@@ -3798,7 +3798,7 @@
           }
         },
         "tags": [
-          "NewsArticles"
+          "News Articles"
         ]
       }
     },
@@ -3812,9 +3812,6 @@
         "summary": "Get news article",
         "description": "Returns the details of a news article with the given article id.",
         "operationId": "get-news-article",
-        "tags": [
-          "NewsArticles"
-        ],
         "responses": {
           "200": {
             "description": "News Article details",
@@ -3844,21 +3841,24 @@
             "$ref": "#/components/responses/NewsArticleNotFound"
           }
         },
-        "x-internal": true
+        "x-internal": true,
+        "tags": [
+          "News Articles"
+        ]
       },
       "delete": {
         "summary": "Delete a news article",
         "operationId": "delete-news-article",
-        "tags": [
-          "NewsArticles"
-        ],
         "responses": {
           "204": {
             "description": "The News Article with the given article id was deleted."
           }
         },
         "description": "Delete a news article with the given article id.",
-        "x-internal": true
+        "x-internal": true,
+        "tags": [
+          "News Articles"
+        ]
       },
       "put": {
         "summary": "Update news article",
@@ -3890,7 +3890,7 @@
           }
         },
         "tags": [
-          "NewsArticles"
+          "News Articles"
         ]
       }
     }
@@ -4157,7 +4157,7 @@
       "name": "Events"
     },
     {
-      "name": "NewsArticles"
+      "name": "News Articles"
     },
     {
       "name": "Organizers"

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3772,8 +3772,8 @@
         ]
       },
       "post": {
-        "summary": "",
-        "operationId": "post-news-articles",
+        "summary": "Add a news article",
+        "operationId": "add-news-article",
         "responses": {
           "201": {
             "description": "The News Article was created successfully",
@@ -3786,7 +3786,7 @@
             }
           }
         },
-        "description": "Create a News Article",
+        "description": "Creates a news article.",
         "x-internal": true,
         "requestBody": {
           "content": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3847,7 +3847,7 @@
         "x-internal": true
       },
       "delete": {
-        "summary": "",
+        "summary": "Delete a news article",
         "operationId": "delete-news-article",
         "tags": [
           "NewsArticles"
@@ -3857,7 +3857,7 @@
             "description": "The News Article with the given article id was deleted."
           }
         },
-        "description": "Delete a News Article with the given article id.",
+        "description": "Delete a news article with the given article id.",
         "x-internal": true
       },
       "put": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3861,7 +3861,7 @@
         "x-internal": true
       },
       "put": {
-        "summary": "",
+        "summary": "Update news article",
         "operationId": "put-news-article",
         "responses": {
           "200": {
@@ -3878,7 +3878,7 @@
             "$ref": "#/components/responses/NewsArticleNotFound"
           }
         },
-        "description": "Update an existing News Article",
+        "description": "Updates an existing news article.",
         "x-internal": true,
         "requestBody": {
           "content": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3809,8 +3809,8 @@
         }
       ],
       "get": {
-        "summary": "Get News Article",
-        "description": "Get the details of a News Article with the given article id.",
+        "summary": "Get news article",
+        "description": "Returns the details of a news article with the given article id.",
         "operationId": "get-news-article",
         "tags": [
           "NewsArticles"


### PR DESCRIPTION
### Added

- Added missing operation summaries (used in sidebar on docs.publiq.be)

### Changed

- Renamed `News Article` in descriptions to just `news article`.
- Changed wording in operation descriptions to describe the operation, not the client. For example `Returns ...` instead of `Get ...`, `Updates ...` instead of `Update ...`. (Think of it as `[This operation] updates ...`)
- Renamed `NewsArticles` tag to `News Articles` so it's more readable in the sidebar on docs.publiq.be
- Changed some operation summaries to be more consistent

---

Note: Maybe we should also analyse if we can document & code these endpoints using `-` instead of `_`, and automatically transform `_` in incoming requests to `-` like we already do for some other cases.

