### PR TITLE
III-4507 Use hyphens in news article paths

### DIFF
--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3786,7 +3786,7 @@
     "/news-articles": {
       "get": {
         "summary": "Get all news articles",
-        "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles`. However the preferred path is `/news-articles`.",
+        "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.\n\n<!-- theme: info -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles`. However the preferred path is `/news-articles`.",
         "operationId": "get-all-news-articles",
         "responses": {
           "200": {
@@ -3893,7 +3893,7 @@
             }
           }
         },
-        "description": "Creates a news article.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles`. However the preferred path is `/news-articles`.",
+        "description": "Creates a news article.\n\n<!-- theme: info -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles`. However the preferred path is `/news-articles`.",
         "x-internal": true,
         "requestBody": {
           "content": {
@@ -3917,7 +3917,7 @@
       ],
       "get": {
         "summary": "Get a news article",
-        "description": "Returns the details of a news article with the given article id.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
+        "description": "Returns the details of a news article with the given article id.\n\n<!-- theme: info -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
         "operationId": "get-news-article",
         "responses": {
           "200": {
@@ -3961,7 +3961,7 @@
             "description": "The News Article with the given article id was deleted."
           }
         },
-        "description": "Delete a news article with the given article id.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
+        "description": "Delete a news article with the given article id.\n\n<!-- theme: info -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
         "x-internal": true,
         "tags": [
           "News articles"
@@ -3985,7 +3985,7 @@
             "$ref": "#/components/responses/NewsArticleNotFound"
           }
         },
-        "description": "Updates an existing news article.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
+        "description": "Updates an existing news article.\n\n<!-- theme: info -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
         "x-internal": true,
         "requestBody": {
           "content": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3786,7 +3786,7 @@
     "/news-articles": {
       "get": {
         "summary": "Get all news articles",
-        "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.  ",
+        "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles`. However the preferred path is `/news-articles`.",
         "operationId": "get-all-news-articles",
         "responses": {
           "200": {
@@ -3893,7 +3893,7 @@
             }
           }
         },
-        "description": "Creates a news article.",
+        "description": "Creates a news article.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles`. However the preferred path is `/news-articles`.",
         "x-internal": true,
         "requestBody": {
           "content": {
@@ -3917,7 +3917,7 @@
       ],
       "get": {
         "summary": "Get a news article",
-        "description": "Returns the details of a news article with the given article id.",
+        "description": "Returns the details of a news article with the given article id.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
         "operationId": "get-news-article",
         "responses": {
           "200": {
@@ -3961,7 +3961,7 @@
             "description": "The News Article with the given article id was deleted."
           }
         },
-        "description": "Delete a news article with the given article id.",
+        "description": "Delete a news article with the given article id.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
         "x-internal": true,
         "tags": [
           "News articles"
@@ -3985,7 +3985,7 @@
             "$ref": "#/components/responses/NewsArticleNotFound"
           }
         },
-        "description": "Updates an existing news article.",
+        "description": "Updates an existing news article.\n\n<!-- theme: warning -->\n\n> For backward compatibility with older API clients, this path is also available at `/news_articles/{articleId}`. However the preferred path is `/news-articles/{articleId}`.",
         "x-internal": true,
         "requestBody": {
           "content": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3783,7 +3783,7 @@
         ]
       }
     },
-    "/news_articles": {
+    "/news-articles": {
       "get": {
         "summary": "Get all news articles",
         "description": "Returns the details of all news articles matching the provided search. The search can be created based on a combination of 3 query parameters:\n- `publisher`\n- `about`\n- `url`\n\nBasic pagination is supported and the results are limited to 30 news articles.\n\nThe extra query parameter `page` can be used to get news articles after the first 30 results.  ",
@@ -3909,7 +3909,7 @@
         ]
       }
     },
-    "/news_articles/{articleId}": {
+    "/news-articles/{articleId}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/articleId"


### PR DESCRIPTION
### Changed

- `news_articles` paths are now documented as `news-articles`

---

Ticket: https://jira.uitdatabank.be/browse/III-4507

