### PR TITLE
Fix organizer patch images summary

### DIFF
--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3719,7 +3719,7 @@
             "$ref": "#/components/responses/OrganizerNotFound"
           }
         },
-        "description": "Update one or more images of an organizer.\n\nThe images to update are identified by their id. It is possible to update one or more of the following properties:\n\n* The `language` of an image\n* The `description` of an image\n* The `copyrightHolder` of an image",
+        "description": "Update one or more images of an organizer.\n\nThe images to update are identified by their `id`. It is possible to update one or more of the following properties:\n\n* The `language` of an image\n* The `description` of an image\n* The `copyrightHolder` of an image\n\nOnly images included in the `PATCH` request will be updated. Other images that also exist on the organizer will not be removed or updated.",
         "security": [
           {
             "USER_ACCESS_TOKEN": []

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3736,7 +3736,7 @@
               }
             }
           },
-          "description": "A list of videos to update."
+          "description": ""
         },
         "tags": [
           "Organizers"

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3693,7 +3693,7 @@
         ]
       },
       "patch": {
-        "summary": "",
+        "summary": "Update image(s)",
         "operationId": "patch-organizer-images",
         "responses": {
           "204": {


### PR DESCRIPTION
### Added

- Added explanation that images that are not included in the `PATCH /organizers/{organizerId}/images` request will not be removed (or updated)
- Added missing summary for `PATCH /organizers/{organizerId}/images`

### Removed

- Removed incorrect and unnecessary request body description for `PATCH /organizers/{organizerId}/images`

