### PR TITLE
III-4426 Make properties optional when adding image

### DIFF
--- a/models/organizer-image-post.json
+++ b/models/organizer-image-post.json
@@ -35,9 +35,6 @@
     }
   },
   "required": [
-    "id",
-    "language",
-    "copyrightHolder",
-    "description"
+    "id"
   ]
 }

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3732,7 +3732,7 @@
           },
           "description": "The image to add to an organizer."
         },
-        "description": "Add an image to an organizer.\n\nThe image objects contains the following properties:\n* `id`: the id of the image.\n* `language`: the language of the image and description.\n* `copyrightHolder`: the copyright holder of the image.\n* `description`: description of the image.\n\nAll properties are required.",
+        "description": "Add an image to an organizer.\n\nThe image objects contains the following properties:\n* `id`: the id of the image which is required\n* `language`: an optional language of the image and description\n* `copyrightHolder`: the optional copyright holder of the image\n* `description`: the description of the image which is also optional",
         "tags": [
           "Organizers"
         ],

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3732,7 +3732,7 @@
           },
           "description": "The image to add to an organizer."
         },
-        "description": "Add an image to an organizer.\n\nThe image objects contains the following properties:\n* `id`: the id of the image which is required\n* `language`: an optional language of the image and description\n* `copyrightHolder`: the optional copyright holder of the image\n* `description`: the description of the image which is also optional",
+        "description": "Add an image to an organizer.\n\nThe image objects contains the following properties:\n* `id`: the id of the image which is required\n* `language`: an optional language of the image and description\n* `copyrightHolder`: the optional copyright holder of the image\n* `description`: the description of the image which is also optional\n\n<!-- theme: info -->\n> The optional fields that are not provided will get the values from the properties of the orginally uploaded image.",
         "tags": [
           "Organizers"
         ],


### PR DESCRIPTION
### Changed
- Only `id` is required when adding an image. The properties `description`, `copyrightHolder` and `language` became optional and will be taken from the existing uploaded image.

---
Ticket: https://jira.uitdatabank.be/browse/III-4426
