### PR TITLE
III-4511 Add id to organizer images

### DIFF
--- a/models/organizer-images.json
+++ b/models/organizer-images.json
@@ -7,6 +7,7 @@
     [
       {
         "@id": "https://io.uitdatabank.be/images/546a90cd-a238-417b-aa98-1b6c50c1345c",
+        "id": "546a90cd-a238-417b-aa98-1b6c50c1345c",
         "contentUrl": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
         "thumbnailUrl": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
         "description": "Een voorbeeld beschrijving",
@@ -27,6 +28,12 @@
           "https://io.uitdatabank.be/images/546a90cd-a238-417b-aa98-1b6c50c1345c"
         ],
         "readOnly": true
+      },
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "The UUID of the image.",
+        "example": "546a90cd-a238-417b-aa98-1b6c50c1345c"
       },
       "contentUrl": {
         "type": "string",
@@ -64,6 +71,7 @@
     },
     "required": [
       "@id",
+      "id",
       "contentUrl",
       "thumbnailUrl",
       "description",

--- a/models/organizer.json
+++ b/models/organizer.json
@@ -61,6 +61,7 @@
       "images": [
         {
           "@id": "https://io.uitdatabank.be/images/546a90cd-a238-417b-aa98-1b6c50c1345c",
+          "id": "546a90cd-a238-417b-aa98-1b6c50c1345c",
           "contentUrl": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
           "thumbnailUrl": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
           "description": "Een voorbeeld beschrijving",

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -2922,6 +2922,7 @@
                       "images": [
                         {
                           "@id": "https://io.uitdatabank.be/images/546a90cd-a238-417b-aa98-1b6c50c1345c",
+                          "id": "546a90cd-a238-417b-aa98-1b6c50c1345c",
                           "contentUrl": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
                           "thumbnailUrl": "https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg",
                           "description": "Een voorbeeld beschrijving",


### PR DESCRIPTION
### Added
- Added `id` to the images of an organizer.

---
Ticket: https://jira.uitdatabank.be/browse/III-4511

