### PR TITLE
Improve description of tokens

### DIFF
--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3913,7 +3913,7 @@
             "scopes": {}
           }
         },
-        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md)"
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
@@ -3924,7 +3924,7 @@
             "scopes": {}
           }
         },
-        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md)"
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },
     "parameters": {


### PR DESCRIPTION
### Changed

- Improved the descriptions of the 2 possible tokens, because some endpoints will only accept one or the other and in that case Stoplight does not show its name (`USER_ACCESS_TOKEN` / `CLIENT_ACCESS_TOKEN`). So it's good to also mention the name in the description. (As seen in the UiTPAS API docs)

