### PR TITLE
III-4411 post organizers

### DIFF
--- a/models/organizer-post-deprecated.json
+++ b/models/organizer-post-deprecated.json
@@ -1,6 +1,6 @@
 {
-  "title": "organizer-post",
   "type": "object",
+  "title": "organizer-post-deprecated",
   "description": "",
   "examples": [
     {
@@ -40,6 +40,7 @@
       ]
     }
   ],
+  "deprecated": true,
   "properties": {
     "@id": {
       "$ref": "./organizer-@id.json"

--- a/models/organizer-workflowStatus.json
+++ b/models/organizer-workflowStatus.json
@@ -8,5 +8,6 @@
   ],
   "examples": [
     "active"
-  ]
+  ],
+  "readOnly": true
 }

--- a/models/organizer.json
+++ b/models/organizer.json
@@ -142,7 +142,6 @@
     }
   },
   "required": [
-    "@id",
     "mainLanguage",
     "url",
     "name"

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -2920,22 +2920,27 @@
     "/organizers": {
       "post": {
         "summary": "Create organizer",
-        "description": "Creates a new organizer. The organizer has several required properties and some optional properties.\n\nThe required properties are:\n- mainLanguage: the language the organizer is created in\n- website: the _unique_ website of the organizer\n- name: the name or title of the organizer in the main language\n\nThe optional properties are:\n- address: the address of the organizer in the main language\n- contact: a list of possible contact details like phone, email or url\n\n<!-- theme: info -->\n\n> Organizers are required to have a unique `website` value to avoid accidental duplicate organizers.",
+        "description": "Creates a new organizer.\n\n<!-- theme: info -->\n\n> Organizers are required to have a unique `url` value to avoid accidental duplicate organizers.\n\n<!-- theme: warning -->\n\n> This request is also supported with an older, deprecated schema that was used to create an organizer with just its required fields.",
         "operationId": "post-organizer",
         "tags": [
           "Organizers"
         ],
         "responses": {
           "201": {
-            "description": "The organizer contact point has been created successfully with the returned id.",
+            "description": "The organizer has been created successfully.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "organizerId": {
+                    "id": {
                       "type": "string",
                       "description": "The id of newly created organizer."
+                    },
+                    "organizerId": {
+                      "type": "string",
+                      "description": "The id of newly created organizer. (Deprecated in favor of `id`.)",
+                      "deprecated": true
                     },
                     "url": {
                       "type": "string",
@@ -2943,6 +2948,7 @@
                     }
                   },
                   "required": [
+                    "id",
                     "organizerId",
                     "url"
                   ]
@@ -2980,7 +2986,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "../models/organizer-post.json"
+                "anyOf": [
+                  {
+                    "$ref": "../models/organizer.json"
+                  },
+                  {
+                    "$ref": "../models/organizer-post-deprecated.json"
+                  }
+                ]
               },
               "examples": {
                 "Create organizer with all possible properties": {

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -2956,6 +2956,7 @@
                 "examples": {
                   "Example": {
                     "value": {
+                      "id": "6b476d79-c404-425f-8b1c-357e39a60410",
                       "organizerId": "6b476d79-c404-425f-8b1c-357e39a60410",
                       "url": "https://io.uitdatabank.be/organizers/6b476d79-c404-425f-8b1c-357e39a60410"
                     }

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3013,13 +3013,13 @@
                       }
                     },
                     "contactPoint": {
-                      "phones": [
+                      "phone": [
                         "+32/1234567890"
                       ],
-                      "emails": [
+                      "email": [
                         "info@publiq.be"
                       ],
-                      "urls": [
+                      "url": [
                         "https://www.publiq.be"
                       ]
                     },

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3000,28 +3000,29 @@
                   "value": {
                     "@id": "https://io.uitdatabank.be/organizers/5cf42d51-3a4f-46f0-a8af-1cf672be8c84",
                     "mainLanguage": "nl",
-                    "name": "Nederlandse naam",
-                    "website": "https://www.publiq.be",
-                    "address": {
-                      "addressCountry": "BE",
-                      "addressLocality": "Brussel",
-                      "postalCode": "1000",
-                      "streetAddress": "Wetstraat 1"
+                    "name": {
+                      "nl": "Nederlandse naam"
                     },
-                    "contact": [
-                      {
-                        "type": "phone",
-                        "value": "+32/1234567890"
-                      },
-                      {
-                        "type": "email",
-                        "value": "info@publiq.be"
-                      },
-                      {
-                        "type": "url",
-                        "value": "https://www.publiq.be"
+                    "url": "https://www.publiq.be",
+                    "address": {
+                      "nl": {
+                        "addressCountry": "BE",
+                        "addressLocality": "Brussel",
+                        "postalCode": "1000",
+                        "streetAddress": "Wetstraat 1"
                       }
-                    ],
+                    },
+                    "contactPoint": {
+                      "phones": [
+                        "+32/1234567890"
+                      ],
+                      "emails": [
+                        "info@publiq.be"
+                      ],
+                      "urls": [
+                        "https://www.publiq.be"
+                      ]
+                    },
                     "labels": [
                       "label1",
                       "label2"

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -2999,7 +2999,6 @@
               "examples": {
                 "Create organizer with all possible properties": {
                   "value": {
-                    "@id": "https://io.uitdatabank.be/organizers/5cf42d51-3a4f-46f0-a8af-1cf672be8c84",
                     "mainLanguage": "nl",
                     "name": {
                       "nl": "Nederlandse naam"


### PR DESCRIPTION
### Changed

- Changed `POST /organizers` to use `organizer.json` schema first and foremost, and also support `organizer-post-deprecated.json`

---

Ticket: https://jira.uitdatabank.be/browse/III-4411

