### PR TITLE
III-4580 Whitespace validation of string properties on organizers

### DIFF
--- a/models/organizer-@id.json
+++ b/models/organizer-@id.json
@@ -1,7 +1,6 @@
 {
   "title": "organizer.@id",
   "type": "string",
-  "minLength": 1,
   "format": "uri",
   "example": "https://io.uitdatabank.be/organizers/5cf42d51-3a4f-46f0-a8af-1cf672be8c84",
   "description": "A unique URI that acts as globally unique ID for the [organizer](./organizer.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",

--- a/models/organizer-address-put.json
+++ b/models/organizer-address-put.json
@@ -6,11 +6,13 @@
       "type": "string",
       "example": "Kerkstraat 2",
       "minLength": 1,
+      "pattern": "\\S",
       "description": "The street name and house number of the address."
     },
     "postalCode": {
       "type": "string",
       "minLength": 1,
+      "pattern": "\\S",
       "example": "3000",
       "description": "The postal code of the address."
     },
@@ -18,6 +20,7 @@
       "type": "string",
       "example": "Leuven",
       "minLength": 1,
+      "pattern": "\\S",
       "description": "The locality (town or city) of the address."
     },
     "addressCountry": {

--- a/models/organizer-address-put.json
+++ b/models/organizer-address-put.json
@@ -24,7 +24,9 @@
       "type": "string",
       "example": "BE",
       "description": "The 2-character code of the country of the address.",
-      "pattern": "^[A-Z]{2}$"
+      "pattern": "^[A-Z]{2}$",
+      "minLength": 1,
+      "maxLength": 2
     }
   },
   "required": [

--- a/models/organizer-address.json
+++ b/models/organizer-address.json
@@ -34,6 +34,7 @@
         "addressLocality": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "Brussel",
           "description": "Municipality of the address in the relevant locale, for example `Brussel` for `nl`."
         },
@@ -41,11 +42,13 @@
           "type": "string",
           "description": "Postal code of the municipality, for example `1000`. Formatted as a string because some international postal codes use letters.",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "1000"
         },
         "streetAddress": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Street address in the relevant locale, for example `Wetstraat 1` for `nl`.",
           "example": "Wetstraat 1"
         }
@@ -72,6 +75,7 @@
         "addressLocality": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "Bruxelles",
           "description": "Municipality of the address in the relevant locale, for example `Bruxelles` for `fr`."
         },
@@ -79,11 +83,13 @@
           "type": "string",
           "description": "Postal code of the municipality, for example `1000`. Formatted as a string because some international postal codes use letters.",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "1000"
         },
         "streetAddress": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Street address in the relevant locale, for example `Rue de la Loi 1` in `fr`.",
           "example": "Rue de la Loi 1"
         }
@@ -110,6 +116,7 @@
         "addressLocality": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "Brüssel",
           "description": "Municipality of the address in the relevant locale."
         },
@@ -117,11 +124,13 @@
           "type": "string",
           "description": "Postal code of the municipality, for example `1000`. Formatted as a string because some international postal codes use letters.",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "1000"
         },
         "streetAddress": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Street address in the relevant locale.",
           "example": "Wetstraat 1"
         }
@@ -148,6 +157,7 @@
         "addressLocality": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "Brussels",
           "description": "Municipality of the address in the relevant locale, for example `Brussels` in `en`."
         },
@@ -155,11 +165,13 @@
           "type": "string",
           "description": "Postal code of the municipality, for example `1000`. Formatted as a string because some international postal codes use letters.",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "1000"
         },
         "streetAddress": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Street address in the relevant locale.",
           "example": "Wetstraat 1"
         }

--- a/models/organizer-contact.json
+++ b/models/organizer-contact.json
@@ -35,7 +35,8 @@
         "type": "string",
         "description": "The real value of the given contact information.",
         "example": "https://www.publiq.be",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "required": [

--- a/models/organizer-contactPoint-put.json
+++ b/models/organizer-contactPoint-put.json
@@ -9,7 +9,8 @@
       "items": {
         "type": "string",
         "description": "Phone number for contact purposes.",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "email": {

--- a/models/organizer-contactPoint.json
+++ b/models/organizer-contactPoint.json
@@ -10,7 +10,8 @@
       "items": {
         "type": "string",
         "description": "Phone number for contact purposes.",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "email": {

--- a/models/organizer-created.json
+++ b/models/organizer-created.json
@@ -4,7 +4,6 @@
   "title": "organizer.created",
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
-  "minLength": 1,
   "examples": [
     "2021-05-17T22:00:00+00:00"
   ],

--- a/models/organizer-description-put.json
+++ b/models/organizer-description-put.json
@@ -6,7 +6,8 @@
       "type": "string",
       "example": "This organizer is responsible for creating cultural events for schools around Brussels.",
       "description": "The description of the organizer (requires at least one character)",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     }
   },
   "required": [

--- a/models/organizer-description.json
+++ b/models/organizer-description.json
@@ -14,21 +14,29 @@
   "properties": {
     "nl": {
       "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
       "description": "Dutch description",
       "example": "Nederlandse beschrijving"
     },
     "fr": {
       "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
       "description": "French description",
       "example": "Description français"
     },
     "de": {
       "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
       "description": "German description",
       "example": "Deutscher Beschreibung"
     },
     "en": {
       "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
       "description": "English description",
       "example": "English description"
     }

--- a/models/organizer-image-post.json
+++ b/models/organizer-image-post.json
@@ -25,12 +25,14 @@
       "type": "string",
       "example": "publiq",
       "minLength": 3,
+      "pattern": "\\S",
       "description": "The copyright holder of the image."
     },
     "description": {
       "type": "string",
       "example": "Picture of the last publiq event",
       "minLength": 1,
+      "pattern": "\\S",
       "description": "Description of the image object, in the language used in the `language` property of the image object."
     }
   },

--- a/models/organizer-images-patch.json
+++ b/models/organizer-images-patch.json
@@ -29,12 +29,14 @@
         "type": "string",
         "example": "publiq",
         "minLength": 3,
+        "pattern": "\\S",
         "description": "The copyright holder of the image."
       },
       "description": {
         "type": "string",
         "example": "Picture of the last publiq event",
         "minLength": 1,
+        "pattern": "\\S",
         "description": "Description of the image object, in the language used in the `language` property of the image object."
       }
     },

--- a/models/organizer-images.json
+++ b/models/organizer-images.json
@@ -53,11 +53,13 @@
       "description": {
         "type": "string",
         "minLength": 1,
+        "pattern": "\\S",
         "description": "Description of the image object, in the language used in the `language` property of the image object."
       },
       "copyrightHolder": {
         "type": "string",
         "minLength": 3,
+        "pattern": "\\S",
         "description": "Name of the copyright holder of the image."
       },
       "language": {

--- a/models/organizer-modified.json
+++ b/models/organizer-modified.json
@@ -2,7 +2,6 @@
   "type": "string",
   "format": "date-time",
   "example": "2021-05-17T22:00:00+00:00",
-  "minLength": 1,
   "title": "organizer.modified",
   "description": "Date formatted as an ISO-8601 datetime, added automatically by UiTdatabank based on the date & time the [organizer](./organizer.json) was last modified.\n\nFor example `2021-05-17T22:00:00+00:00`.",
   "examples": [

--- a/models/organizer-name-put.json
+++ b/models/organizer-name-put.json
@@ -6,7 +6,8 @@
       "type": "string",
       "example": "publiq",
       "description": "The new name of the organizer (requires at least one character)",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     }
   },
   "required": [

--- a/models/organizer-name.json
+++ b/models/organizer-name.json
@@ -16,25 +16,29 @@
       "type": "string",
       "description": "Dutch name",
       "example": "Nederlandse naam",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "fr": {
       "type": "string",
       "description": "French name",
       "example": "Nom français",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "de": {
       "type": "string",
       "description": "German name",
       "example": "Deutscher Name",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "en": {
       "type": "string",
       "description": "English name",
       "example": "English name",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     }
   }
 }

--- a/models/organizer-post-deprecated.json
+++ b/models/organizer-post-deprecated.json
@@ -58,7 +58,8 @@
     "name": {
       "type": "string",
       "description": "The name of the organizer",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "address": {
       "type": "object",
@@ -67,6 +68,7 @@
         "streetAddress": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Street address in the main language, for example `Wetstraat 1` for `nl`.",
           "example": "Wetstraat 1"
         },
@@ -74,11 +76,13 @@
           "type": "string",
           "description": "Postal code of the municipality, for example `1000`. Formatted as a string because some international postal codes use letters.",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "1000"
         },
         "addressLocality": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "example": "Brussel",
           "description": "Municipality of the address in the main language, for example `Brussel` for `nl`."
         },


### PR DESCRIPTION
### Added

- Added non-whitespace character check on organizer properties that are strings with a minLength
- Added minLength and maxLength to organizer address countryCode for `PUT /organizers/\{id\}/address` (consistent with address in other places)

### Removed

- Removed minLength from string properties on organizers that have a format like `uuid` or `datetime`

---

Ticket: https://jira.uitdatabank.be/browse/III-4580

I'll also create a PR for udb3-silex to update the schemas there and fix/add some tests

