### PR TITLE
III-4362 Tweaks for event schema validation

### DIFF
--- a/models/common-creator.json
+++ b/models/common-creator.json
@@ -1,6 +1,7 @@
 {
   "x-internal": true,
   "title": "creator",
+  "type": "string",
   "description": "The unique identifier of the user or API client that created the document.",
   "examples": [
     "auth0|45c0d021-c78f-445f-adef-be3355b23e4f",

--- a/models/common-label.json
+++ b/models/common-label.json
@@ -5,7 +5,7 @@
   "type": "string",
   "minLength": 2,
   "maxLength": 255,
-  "pattern": "^[^;]{2,255}$",
+  "pattern": "^(?=.{2,255}$)(?=.*\\S.*\\S.*)[^;]*$",
   "examples": [
     "example label 12345!"
   ]

--- a/models/event-subEvent.json
+++ b/models/event-subEvent.json
@@ -64,11 +64,8 @@
       }
     },
     "required": [
-      "id",
       "startDate",
-      "endDate",
-      "status",
-      "bookingAvailability"
+      "endDate"
     ]
   }
 }

--- a/models/event-terms.json
+++ b/models/event-terms.json
@@ -4,6 +4,13 @@
   "description": "A list of taxonomy terms used to categorize the [event](./event.json).\n\nTerms are pre-defined and can be browsed in our [Terms](../docs/terms.md) guide.\n\nAn event requires at least one term, to define its type. (For example a concert, theater show, ...)",
   "uniqueItems": true,
   "minItems": 1,
+  "contains": {
+    "properties": {
+      "domain": {"const": "eventtype"}
+    }
+  },
+  "minContains": 1,
+  "maxContains": 1,
   "items": {
     "title": "",
     "type": "object",

--- a/models/event.json
+++ b/models/event.json
@@ -404,16 +404,7 @@
     "@id",
     "mainLanguage",
     "name",
-    "calendarType",
-    "status",
-    "availableFrom",
-    "availableTo",
     "terms",
-    "created",
-    "creator",
-    "workflowStatus",
-    "audience",
-    "languages",
-    "completedLanguages"
+    "calendarType"
   ]
 }

--- a/models/event.json
+++ b/models/event.json
@@ -311,6 +311,9 @@
         "terms": {
           "$ref": "./event-terms.json"
         },
+        "location": {
+          "$ref": "./event-location.json"
+        },
         "calendarType": {
           "$ref": "./event-calendarType.json"
         },
@@ -334,9 +337,6 @@
         },
         "availableTo": {
           "$ref": "./event-availableTo.json"
-        },
-        "location": {
-          "$ref": "./event-location.json"
         },
         "organizer": {
           "$ref": "./event-organizer.json"
@@ -407,6 +407,7 @@
         "mainLanguage",
         "name",
         "terms",
+        "location",
         "calendarType"
       ]
     },

--- a/models/event.json
+++ b/models/event.json
@@ -342,15 +342,6 @@
     "sameAs": {
       "$ref": "./event-sameAs.json"
     },
-    "created": {
-      "$ref": "./event-created.json"
-    },
-    "modified": {
-      "$ref": "./event-modified.json"
-    },
-    "creator": {
-      "$ref": "./event-creator.json"
-    },
     "workflowStatus": {
       "$ref": "./event-workflowStatus.json"
     },
@@ -398,6 +389,15 @@
     },
     "bookingAvailability": {
       "$ref": "./event-bookingAvailability.json"
+    },
+    "created": {
+      "$ref": "./event-created.json"
+    },
+    "modified": {
+      "$ref": "./event-modified.json"
+    },
+    "creator": {
+      "$ref": "./event-creator.json"
     }
   },
   "required": [

--- a/models/event.json
+++ b/models/event.json
@@ -306,6 +306,9 @@
     "name": {
       "$ref": "./event-name.json"
     },
+    "terms": {
+      "$ref": "./event-terms.json"
+    },
     "calendarType": {
       "$ref": "./event-calendarType.json"
     },
@@ -338,9 +341,6 @@
     },
     "sameAs": {
       "$ref": "./event-sameAs.json"
-    },
-    "terms": {
-      "$ref": "./event-terms.json"
     },
     "created": {
       "$ref": "./event-created.json"

--- a/models/event.json
+++ b/models/event.json
@@ -296,115 +296,174 @@
     }
   ],
   "title": "event",
-  "properties": {
-    "@id": {
-      "$ref": "./event-@id.json"
+  "allOf": [
+    {
+      "properties": {
+        "@id": {
+          "$ref": "./event-@id.json"
+        },
+        "mainLanguage": {
+          "$ref": "./event-mainLanguage.json"
+        },
+        "name": {
+          "$ref": "./event-name.json"
+        },
+        "terms": {
+          "$ref": "./event-terms.json"
+        },
+        "calendarType": {
+          "$ref": "./event-calendarType.json"
+        },
+        "startDate": {
+          "$ref": "./event-startDate.json"
+        },
+        "endDate": {
+          "$ref": "./event-endDate.json"
+        },
+        "status": {
+          "$ref": "./event-status.json"
+        },
+        "subEvent": {
+          "$ref": "./event-subEvent.json"
+        },
+        "openingHours": {
+          "$ref": "./event-openingHours.json"
+        },
+        "availableFrom": {
+          "$ref": "./event-availableFrom.json"
+        },
+        "availableTo": {
+          "$ref": "./event-availableTo.json"
+        },
+        "location": {
+          "$ref": "./event-location.json"
+        },
+        "organizer": {
+          "$ref": "./event-organizer.json"
+        },
+        "sameAs": {
+          "$ref": "./event-sameAs.json"
+        },
+        "workflowStatus": {
+          "$ref": "./event-workflowStatus.json"
+        },
+        "audience": {
+          "$ref": "./event-audience.json"
+        },
+        "languages": {
+          "$ref": "./event-languages.json"
+        },
+        "completedLanguages": {
+          "$ref": "./event-completedLanguages.json"
+        },
+        "typicalAgeRange": {
+          "$ref": "./event-typicalAgeRange.json"
+        },
+        "description": {
+          "$ref": "./event-description.json"
+        },
+        "priceInfo": {
+          "$ref": "./event-priceInfo.json"
+        },
+        "contactPoint": {
+          "$ref": "./event-contactPoint.json"
+        },
+        "bookingInfo": {
+          "$ref": "./event-bookingInfo.json"
+        },
+        "mediaObject": {
+          "$ref": "./event-mediaObject.json"
+        },
+        "image": {
+          "$ref": "./event-image.json"
+        },
+        "videos": {
+          "$ref": "./event-videos.json"
+        },
+        "labels": {
+          "$ref": "./event-labels.json"
+        },
+        "hiddenLabels": {
+          "$ref": "./event-hiddenLabels.json"
+        },
+        "production": {
+          "$ref": "./event-production.json"
+        },
+        "bookingAvailability": {
+          "$ref": "./event-bookingAvailability.json"
+        },
+        "created": {
+          "$ref": "./event-created.json"
+        },
+        "modified": {
+          "$ref": "./event-modified.json"
+        },
+        "creator": {
+          "$ref": "./event-creator.json"
+        }
+      },
+      "required": [
+        "@id",
+        "mainLanguage",
+        "name",
+        "terms",
+        "calendarType"
+      ]
     },
-    "mainLanguage": {
-      "$ref": "./event-mainLanguage.json"
+    {
+      "if": {
+        "required": [
+          "calendarType"
+        ],
+        "properties": {
+          "calendarType": {
+            "const": "periodic"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "startDate",
+          "endDate"
+        ]
+      }
     },
-    "name": {
-      "$ref": "./event-name.json"
+    {
+      "if": {
+        "required": [
+          "calendarType"
+        ],
+        "properties": {
+          "calendarType": {
+            "const": "single"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "startDate",
+          "endDate"
+        ]
+      }
     },
-    "terms": {
-      "$ref": "./event-terms.json"
-    },
-    "calendarType": {
-      "$ref": "./event-calendarType.json"
-    },
-    "startDate": {
-      "$ref": "./event-startDate.json"
-    },
-    "endDate": {
-      "$ref": "./event-endDate.json"
-    },
-    "status": {
-      "$ref": "./event-status.json"
-    },
-    "subEvent": {
-      "$ref": "./event-subEvent.json"
-    },
-    "openingHours": {
-      "$ref": "./event-openingHours.json"
-    },
-    "availableFrom": {
-      "$ref": "./event-availableFrom.json"
-    },
-    "availableTo": {
-      "$ref": "./event-availableTo.json"
-    },
-    "location": {
-      "$ref": "./event-location.json"
-    },
-    "organizer": {
-      "$ref": "./event-organizer.json"
-    },
-    "sameAs": {
-      "$ref": "./event-sameAs.json"
-    },
-    "workflowStatus": {
-      "$ref": "./event-workflowStatus.json"
-    },
-    "audience": {
-      "$ref": "./event-audience.json"
-    },
-    "languages": {
-      "$ref": "./event-languages.json"
-    },
-    "completedLanguages": {
-      "$ref": "./event-completedLanguages.json"
-    },
-    "typicalAgeRange": {
-      "$ref": "./event-typicalAgeRange.json"
-    },
-    "description": {
-      "$ref": "./event-description.json"
-    },
-    "priceInfo": {
-      "$ref": "./event-priceInfo.json"
-    },
-    "contactPoint": {
-      "$ref": "./event-contactPoint.json"
-    },
-    "bookingInfo": {
-      "$ref": "./event-bookingInfo.json"
-    },
-    "mediaObject": {
-      "$ref": "./event-mediaObject.json"
-    },
-    "image": {
-      "$ref": "./event-image.json"
-    },
-    "videos": {
-      "$ref": "./event-videos.json"
-    },
-    "labels": {
-      "$ref": "./event-labels.json"
-    },
-    "hiddenLabels": {
-      "$ref": "./event-hiddenLabels.json"
-    },
-    "production": {
-      "$ref": "./event-production.json"
-    },
-    "bookingAvailability": {
-      "$ref": "./event-bookingAvailability.json"
-    },
-    "created": {
-      "$ref": "./event-created.json"
-    },
-    "modified": {
-      "$ref": "./event-modified.json"
-    },
-    "creator": {
-      "$ref": "./event-creator.json"
+    {
+      "if": {
+        "required": [
+          "calendarType"
+        ],
+        "properties": {
+          "calendarType": {
+            "const": "multiple"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "startDate",
+          "endDate",
+          "subEvent"
+        ]
+      }
     }
-  },
-  "required": [
-    "@id",
-    "mainLanguage",
-    "name",
-    "terms",
-    "calendarType"
   ]
 }

--- a/models/event.json
+++ b/models/event.json
@@ -442,8 +442,7 @@
       },
       "then": {
         "required": [
-          "startDate",
-          "endDate"
+          "subEvent"
         ]
       }
     },
@@ -460,8 +459,6 @@
       },
       "then": {
         "required": [
-          "startDate",
-          "endDate",
           "subEvent"
         ]
       }

--- a/models/organizer-hiddenLabels.json
+++ b/models/organizer-hiddenLabels.json
@@ -2,5 +2,5 @@
   "$ref": "./common-labels.json",
   "x-internal": false,
   "title": "organizer.hiddenLabels",
-  "description": "Same as [labels](./organizer-labels.json), but for labels that should not be visible for end users on publication channels and should instead only be used for filtering or other processing.\n\nLabels must match the `^[^;]{2,255}$` pattern."
+  "description": "Same as [labels](./organizer-labels.json), but for labels that should not be visible for end users on publication channels and should instead only be used for filtering or other processing.\n\nLabels must match the `^(?=.{2,255}$)(?=.*\\S.*\\S.*)[^;]*$` pattern."
 }

--- a/models/organizer-labels.json
+++ b/models/organizer-labels.json
@@ -2,5 +2,5 @@
   "$ref": "./common-labels.json",
   "x-internal": false,
   "title": "organizer.labels",
-  "description": "One or more labels that categorize the [organizer](./organizer.json). Labels do not have a defined set of possible values or a hierarchy.\n\nLabels are allowed to be visible for end users on publication channels.\n\nLabels must match the `^[^;]{2,255}$` pattern.\n\nSee [hiddenLabels](./organizer-hiddenLabels.json) for labels that should not be visible on publication channels."
+  "description": "One or more labels that categorize the [organizer](./organizer.json). Labels do not have a defined set of possible values or a hierarchy.\n\nLabels are allowed to be visible for end users on publication channels.\n\nLabels must match the `^(?=.{2,255}$)(?=.*\\S.*\\S.*)[^;]*$` pattern.\n\nSee [hiddenLabels](./organizer-hiddenLabels.json) for labels that should not be visible on publication channels."
 }

--- a/reference/entry.json
+++ b/reference/entry.json
@@ -3690,7 +3690,7 @@
       ],
       "put": {
         "summary": "Add label",
-        "description": "Adds the given label to the organizer with the given `organizerId`.\n\nIf the specified label does not exist yet in UiTdatabank a new label will be created with default visibility and public permissions (usable by anyone), and linked to the organizer.\n\nThe label must be longer than 1 character and shorter than 255 characters. The label can also not contain the semicolon character. It should match the regex `^[^;]{2,255}$`",
+        "description": "Adds the given label to the organizer with the given `organizerId`.\n\nIf the specified label does not exist yet in UiTdatabank a new label will be created with default visibility and public permissions (usable by anyone), and linked to the organizer.\n\nThe label must be longer than 1 character and shorter than 255 characters. The label can also not contain the semicolon character. It should match the regex `^(?=.{2,255}$)(?=.*\\S.*\\S.*)[^;]*$`",
         "operationId": "put-organizer-label",
         "tags": [
           "Organizers"
@@ -3740,7 +3740,7 @@
       },
       "delete": {
         "summary": "Delete label",
-        "description": "Deletes the given label from the organizer with the given `organizerId`.\n\nThe label must be longer than 1 character and shorter than 255 characters. The label can also not contain the semicolon character. It should match the regex `^[^;]{2,255}$`",
+        "description": "Deletes the given label from the organizer with the given `organizerId`.\n\nThe label must be longer than 1 character and shorter than 255 characters. The label can also not contain the semicolon character. It should match the regex `^(?=.{2,255}$)(?=.*\\S.*\\S.*)[^;]*$`",
         "operationId": "delete-organizer-label",
         "tags": [
           "Organizers"
@@ -4951,7 +4951,7 @@
         "schema": {
           "type": "string",
           "example": "MyLabel",
-          "pattern": "^[^;]{2,255}$"
+          "pattern": "^(?=.{2,255}$)(?=.*\\S.*\\S.*)[^;]*$"
         },
         "description": "The label to add to an event, place or organizer. The label name should be longer than 1 character but shorter than 255 characters. The label name should not contain semicolons."
       },

--- a/reference/taxonomy.json
+++ b/reference/taxonomy.json
@@ -369,14 +369,6 @@
       "parameters": []
     }
   },
-  "components": {
-    "schemas": {
-      "Error": {
-        "$ref": "https://raw.githubusercontent.com/cultuurnet/stoplight-docs-errors/main/models/Error.json"
-      }
-    },
-    "securitySchemes": {}
-  },
   "tags": [
     {
       "name": "Terms"


### PR DESCRIPTION
### Added
- Added if-then block for calendar type validation

### Changed
- Marked some event and subEvent properties no longer as required
- Marked location as required
- Reordered the required properties at the top
- Only allow a single `eventtype` term
- Used enhanced label regex pattern

---

Ticket: https://jira.uitdatabank.be/browse/III-4362