### PR TITLE
API-67 Fix Postman downloads

### DIFF
--- a/models/common-address-localized.json
+++ b/models/common-address-localized.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "title": "address.localized",
   "description": "An address localized in a single language.",

--- a/models/common-address.json
+++ b/models/common-address.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "title": "address",
   "description": "An internationalized address with one or more localized addresses.\n\nImportant: Only add a localized address if it's an official variant!",

--- a/models/common-bookingAvailability.json
+++ b/models/common-bookingAvailability.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "bookingAvailability",
   "type": "object",
   "description": "Indicates whether the there are tickets or reservations available. Currently only contains a `type` that can be `Available` or `Unavailable`, but can later be expanded with more detailed info.",

--- a/models/common-bookingInfo.json
+++ b/models/common-bookingInfo.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "bookingInfo",
   "type": "object",
   "description": "Booking info to buy tickets or reserve a place, containing one or more phone numbers, email addresses, and/or website URLs.",

--- a/models/common-coordinates.json
+++ b/models/common-coordinates.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "coordinates",
   "type": "object",
   "properties": {

--- a/models/common-copyrightHolder.json
+++ b/models/common-copyrightHolder.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "copyrightHolder",
   "type": "string",
   "example": "publiq",

--- a/models/common-creator.json
+++ b/models/common-creator.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "creator",
   "type": "string",
   "description": "The unique identifier of the user or API client that created the document.",

--- a/models/common-description-localized.json
+++ b/models/common-description-localized.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "string",
   "title": "description.localized",
   "description": "A human-readable description localized in a single value.",

--- a/models/common-description.json
+++ b/models/common-description.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "title": "description",
   "description": "An internationalized description with one or more localized descriptions.",

--- a/models/common-images.json
+++ b/models/common-images.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "array",
   "title": "images",
   "minItems": 1,

--- a/models/common-label.json
+++ b/models/common-label.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "label",
   "description": "String of 2-255 characters. Can contain any characters except for semicolons (`;`).",
   "type": "string",

--- a/models/common-labels.json
+++ b/models/common-labels.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "labels",
   "description": "A list of multiple labels.",
   "type": "array",

--- a/models/common-language.json
+++ b/models/common-language.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "language",
   "type": "string",
   "example": "nl",

--- a/models/common-languages.json
+++ b/models/common-languages.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "array",
   "title": "languages",
   "readOnly": true,

--- a/models/common-mainImage.json
+++ b/models/common-mainImage.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "$ref": "./common-string-uri-readOnly.json",
   "title": "common.mainImage",
   "examples": [

--- a/models/common-mainLanguage.json
+++ b/models/common-mainLanguage.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "mainLanguage",
   "description": "Original language of the document when it was created. Every translatable property is required to have at least a value for this language.",
   "type": "string",

--- a/models/common-name-localized.json
+++ b/models/common-name-localized.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "string",
   "title": "name.localized",
   "description": "A human-readable name localized in a single value.",

--- a/models/common-name.json
+++ b/models/common-name.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "title": "name",
   "description": "An internationalized name with one or more localized names.",

--- a/models/common-openingHours.json
+++ b/models/common-openingHours.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "openingHours",
   "type": "array",
   "items": {

--- a/models/common-priceInfo.json
+++ b/models/common-priceInfo.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "array",
   "title": "priceInfo",
   "description": "A list of prices for tickets/reservations.",

--- a/models/common-sameAs.json
+++ b/models/common-sameAs.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "array",
   "title": "sameAs",
   "uniqueItems": true,

--- a/models/common-status.json
+++ b/models/common-status.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "status",
   "type": "object",
   "properties": {

--- a/models/common-string-datetime-readOnly.json
+++ b/models/common-string-datetime-readOnly.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "datetime.readOnly",
   "type": "string",
   "format": "date-time",

--- a/models/common-string-datetime.json
+++ b/models/common-string-datetime.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "datetime",
   "type": "string",
   "format": "date-time",

--- a/models/common-string-uri-readOnly.json
+++ b/models/common-string-uri-readOnly.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "uri.readOnly",
   "description": "A URI with the HTTP or HTTPS protocol. (Read-only)",
   "type": "string",

--- a/models/common-string-uri-video.json
+++ b/models/common-string-uri-video.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "uri.video",
   "type": "string",
   "format": "uri",

--- a/models/common-string-uri.json
+++ b/models/common-string-uri.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "uri",
   "description": "A URI with the HTTP or HTTPS protocol.",
   "type": "string",

--- a/models/common-string-uuid-readOnly.json
+++ b/models/common-string-uuid-readOnly.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "uuid",
   "type": "string",
   "format": "uuid",

--- a/models/common-string-uuid.json
+++ b/models/common-string-uuid.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "uuid",
   "type": "string",
   "format": "uuid",

--- a/models/common-typicalAgeRange.json
+++ b/models/common-typicalAgeRange.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "string",
   "title": "typicalAgeRange",
   "examples": [

--- a/models/common-videos-post.json
+++ b/models/common-videos-post.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "videos.post",
   "type": "object",
   "properties": {

--- a/models/common-videos.json
+++ b/models/common-videos.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "videos",
   "type": "array",
   "items": {

--- a/models/common-workflowStatus-offer.json
+++ b/models/common-workflowStatus-offer.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "workflowStatus",
   "type": "string",
   "description": "The status in the moderation workflow.\n\nCan be one of four types:\n\n- `DRAFT`: Should not be visible on publication channels yet\n- `READY_FOR_VALIDATION`: Submitted for validation. Some publication channels may choose to show these.\n- `APPROVED`: Approved, will be visible on all publication channels (depending on the `availableFrom` and `availableTo`)\n- `DELETED`: Removed and should not be visible on any publication channels.",

--- a/models/event-availableFrom-put.json
+++ b/models/event-availableFrom-put.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "event.availableFrom.put",
   "type": "object",
   "properties": {

--- a/models/event-calendar-put-deprecated.json
+++ b/models/event-calendar-put-deprecated.json
@@ -1,6 +1,5 @@
 {
   "title": "event.calendar.put (deprecated)",
-  "x-internal": true,
   "deprecated": true,
   "type": "object",
   "description": "",

--- a/models/event-calendar-put.json
+++ b/models/event-calendar-put.json
@@ -1,6 +1,5 @@
 {
   "title": "event.calendar.put",
-  "x-internal": true,
   "type": "object",
   "description": "",
   "allOf": [

--- a/models/event-facilities-put.json
+++ b/models/event-facilities-put.json
@@ -1,6 +1,5 @@
 {
   "title": "event.facilities.put",
-  "x-internal": true,
   "type": "array",
   "uniqueItems": true,
   "items": {

--- a/models/event-post-deprecated.json
+++ b/models/event-post-deprecated.json
@@ -1,7 +1,6 @@
 {
   "title": "event.post (deprecated)",
   "type": "object",
-  "x-internal": true,
   "properties": {
     "mainlanguage": {
       "$ref": "./event-mainLanguage.json"

--- a/models/event-subEvent-patch.json
+++ b/models/event-subEvent-patch.json
@@ -1,6 +1,5 @@
 {
   "title": "event.subEvent.patch",
-  "x-internal": true,
   "type": "array",
   "minItems": 1,
   "uniqueItems": true,

--- a/models/event-subEvent-put.json
+++ b/models/event-subEvent-put.json
@@ -1,7 +1,6 @@
 {
   "title": "event.subEvent.put",
   "type": "array",
-  "x-internal": true,
   "description": "",
   "examples": [
     [

--- a/models/event-videos-patch.json
+++ b/models/event-videos-patch.json
@@ -1,6 +1,5 @@
 {
   "$ref": "./common-videos-patch.json",
-  "x-internal": true,
   "title": "event.videos.patch",
   "description": "Describes the request body to update one or more videos on an event."
 }

--- a/models/event-videos-post.json
+++ b/models/event-videos-post.json
@@ -1,6 +1,5 @@
 {
   "$ref": "./common-videos-post.json",
-  "x-internal": true,
   "title": "event.videos.post",
   "description": "Describes the request body to add a video to an event."
 }

--- a/models/image.json
+++ b/models/image.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "properties": {
     "@id": {

--- a/models/organizer-address-put.json
+++ b/models/organizer-address-put.json
@@ -1,6 +1,5 @@
 {
   "$ref": "./common-address-localized.json",
-  "x-internal": true,
   "title": "organizer.address.put",
   "description": "New address of the organizer, localized in a single language."
 }

--- a/models/organizer-description-put.json
+++ b/models/organizer-description-put.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "organizer.description.put",
   "type": "object",
   "properties": {

--- a/models/organizer-name-put.json
+++ b/models/organizer-name-put.json
@@ -1,6 +1,5 @@
 {
   "title": "organizer.name.put",
-  "x-internal": true,
   "type": "object",
   "properties": {
     "name": {

--- a/models/organizer-post-deprecated.json
+++ b/models/organizer-post-deprecated.json
@@ -1,6 +1,5 @@
 {
   "title": "organizer.post.deprecated",
-  "x-internal": true,
   "type": "object",
   "deprecated": true,
   "properties": {

--- a/models/organizer-reference.json
+++ b/models/organizer-reference.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "title": "organizer.reference",
   "examples": [

--- a/models/organizer-url-put.json
+++ b/models/organizer-url-put.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "organizer-url-put",
   "type": "object",
   "properties": {

--- a/models/place-availableFrom-put.json
+++ b/models/place-availableFrom-put.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "title": "event.availableFrom.put",
   "type": "object",
   "properties": {

--- a/models/place-calendar-put.json
+++ b/models/place-calendar-put.json
@@ -1,6 +1,5 @@
 {
   "title": "place.calendar.put",
-  "x-internal": true,
   "type": "object",
   "description": "",
   "properties": {

--- a/models/place-facilities-put.json
+++ b/models/place-facilities-put.json
@@ -1,6 +1,5 @@
 {
   "title": "place.facilities.put",
-  "x-internal": true,
   "type": "array",
   "uniqueItems": true,
   "items": {

--- a/models/place-post-deprecated.json
+++ b/models/place-post-deprecated.json
@@ -1,7 +1,6 @@
 {
   "title": "place-post-deprecated",
   "type": "object",
-  "x-internal": true,
   "properties": {
     "mainLanguage": {
       "$ref": "./place-mainLanguage.json"

--- a/models/place-reference.json
+++ b/models/place-reference.json
@@ -1,5 +1,4 @@
 {
-  "x-internal": true,
   "type": "object",
   "title": "place.reference",
   "examples": [

--- a/models/place-videos-patch.json
+++ b/models/place-videos-patch.json
@@ -1,6 +1,5 @@
 {
   "$ref": "./common-videos-patch.json",
-  "x-internal": true,
   "title": "place.videos.patch",
   "description": "Describes the request body to update one or more videos on a place."
 }

--- a/models/place-videos-post.json
+++ b/models/place-videos-post.json
@@ -1,6 +1,5 @@
 {
   "$ref": "./common-videos-post.json",
-  "x-internal": true,
   "title": "place.videos.post",
   "description": "Describes the request body to add a video to a place."
 }


### PR DESCRIPTION
### Fixed

- Removed `"x-internal": true` from models that are used in public operations. Otherwise they do not get included in the dereferenced OpenAPI file when fetched from Stoplight.
- Removed `"x-internal": false` overrides on other models that are not needed anymore

---

Ticket: https://jira.uitdatabank.be/browse/API-67

Note: Changes from https://github.com/cultuurnet/openapi2postman/pull/1 are also needed to make it work completely, and that still requires an update of said package in https://github.com/cultuurnet/openapi2postman-frontend

